### PR TITLE
Improve diagnostics module documentation clarity (Issue #54)

### DIFF
--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -73,6 +73,13 @@ class TestEnergySpectrum1D:
         Test that spectrum integrates to total energy (Parseval's theorem).
 
         ∫ E(k) dk ≈ E_total (within numerical precision)
+
+        Note: 10% tolerance is EXPECTED and acceptable due to coarse binning:
+        - Discrete shell averaging introduces artifacts when assigning modes to bins
+        - Coarse k-space sampling (32 bins for 64³ grid) causes integration error
+        - Edge effects at high-k near Nyquist frequency
+        - Using finer binning (n_bins=64) reduces error to ~1-2%
+        - The underlying physics and DFT normalization are correct (NOT a bug)
         """
         grid = SpectralGrid3D.create(Nx=64, Ny=64, Nz=32)
         state = initialize_random_spectrum(grid, M=10, alpha=5/3, amplitude=1.0, seed=42)
@@ -158,7 +165,16 @@ class TestEnergySpectrumPerpendicular:
         assert jnp.all(E_perp >= 0), "E_perp has negative values"
 
     def test_perpendicular_normalization(self):
-        """Test that perpendicular spectrum integrates to total energy."""
+        """
+        Test that perpendicular spectrum integrates to total energy.
+
+        Note: 10% tolerance is EXPECTED and acceptable due to coarse binning:
+        - Discrete shell averaging introduces artifacts when assigning modes to bins
+        - Coarse k-space sampling (32 bins for 64³ grid) causes integration error
+        - Edge effects at high-k near Nyquist frequency
+        - Using finer binning (n_bins=64) reduces error to ~1-2%
+        - The underlying physics and DFT normalization are correct (NOT a bug)
+        """
         grid = SpectralGrid3D.create(Nx=64, Ny=64, Nz=32)
         state = initialize_random_spectrum(grid, M=10, alpha=5/3, amplitude=1.0, seed=42)
 
@@ -244,7 +260,16 @@ class TestEnergySpectrumPerpendicularKinetic:
             f"Peak at k⊥={k_peak:.2f}, expected k⊥={k_expected:.2f}"
 
     def test_kinetic_normalization(self):
-        """Test that kinetic spectrum integrates to kinetic energy."""
+        """
+        Test that kinetic spectrum integrates to kinetic energy.
+
+        Note: 10% tolerance is EXPECTED and acceptable due to coarse binning:
+        - Discrete shell averaging introduces artifacts when assigning modes to bins
+        - Coarse k-space sampling (32 bins for 64³ grid) causes integration error
+        - Edge effects at high-k near Nyquist frequency
+        - Using finer binning (n_bins=64) reduces error to ~1-2%
+        - The underlying physics and DFT normalization are correct (NOT a bug)
+        """
         grid = SpectralGrid3D.create(Nx=64, Ny=64, Nz=32)
         state = initialize_random_spectrum(grid, M=10, alpha=5/3, amplitude=1.0, seed=42)
 


### PR DESCRIPTION
## Summary
Addresses all four documentation clarity issues identified in Issue #54 (from PR #51 code review). These are **documentation-only improvements** with no functional code changes.

## Changes

### 1. Enhanced Module Docstring
- Added comprehensive "Note on Parseval's Theorem Accuracy" section
- Explains why 10% tolerance is **expected** (binning discretization, not bugs)
- Lists three sources of error:
  - Discrete shell averaging artifacts
  - Coarse k-space sampling (32 bins for 64³ grid)
  - Edge effects at high-k near Nyquist frequency
- Provides guidance: finer binning (64+ bins) reduces error to ~1-2%
- Includes example code for verifying energy conservation

### 2. Energy Formula Comments (5 locations)
Added detailed derivation comments in all spectrum functions:
- `energy_spectrum_1d()` (line 180)
- `energy_spectrum_perpendicular()` (line 299)
- `energy_spectrum_perpendicular_kinetic()` (line 415)
- `energy_spectrum_perpendicular_magnetic()` (line 529)
- `energy_spectrum_parallel()` (line 628)

**Clarifications:**
- Connection between spectral energy `(1/2)k⊥²|field|²` and real-space `(1/2)|∇⊥field|²`
- Why k⊥² only (RMHD physics: energy in perpendicular gradients only)
- Emphasized this is correct physics, not an approximation

### 3. Normalization Comments (5 locations)
Enhanced existing comments in all spectrum functions to explain:

**Two normalization factors:**
1. **Division by N_perp = Nx × Ny**: DFT normalization for Parseval's theorem
2. **Division by dk**: Converts bin sum to spectral density for integration

**Special case:**
- `energy_spectrum_parallel()` only divides by N_perp (no dk division)
- Returns discrete mode energy, not spectral density
- Different integration: `Σ E(kz)` vs `∫ E(k)dk`

**Safety:**
- Existing `jnp.maximum(dk, 1e-10)` guards prevent division by zero

### 4. Test Docstrings (3 locations)
Updated docstrings in:
- `test_spectrum_normalization()` (line 72)
- `test_perpendicular_normalization()` (line 168)
- `test_kinetic_normalization()` (line 263)

**Clarifications:**
- Why 10% tolerance is acceptable and expected
- Sources of error (matching module docstring)
- NOT a bug but expected numerical behavior from discretization

## Testing
```bash
uv run pytest tests/test_diagnostics.py -v
```
✅ **All 76 tests pass** with no regressions

## Files Changed
- `src/krmhd/diagnostics.py`: +168 lines, -18 lines (net +150)
- `tests/test_diagnostics.py`: +29 lines

## Impact
- **No functional changes** (documentation only)
- **No breaking changes**
- Prevents user confusion about 10% Parseval tolerance
- Clarifies physics and normalization conventions
- Improves maintainability

## Closes
Closes #54