### PR TITLE
Fix Docker workflow tag mismatch in verification step

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -102,12 +102,18 @@ jobs:
 
       - name: Verify CPU image
         run: |
-          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
-          docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }} python -c 'import krmhd; print("KRMHD imported successfully")'
+          # Strip 'v' prefix from tag if present (e.g., v0.2.0 -> 0.2.0)
+          TAG_NAME="${{ github.ref_name }}"
+          TAG_NAME="${TAG_NAME#v}"
+          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG_NAME}
+          docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG_NAME} python -c 'import krmhd; print("KRMHD imported successfully")'
           echo "✅ CPU image verified"
 
       - name: Verify CUDA image
         run: |
-          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-cuda
-          docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-cuda python -c 'import krmhd; print("KRMHD imported successfully")'
+          # Strip 'v' prefix from tag if present (e.g., v0.2.0 -> 0.2.0)
+          TAG_NAME="${{ github.ref_name }}"
+          TAG_NAME="${TAG_NAME#v}"
+          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG_NAME}-cuda
+          docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG_NAME}-cuda python -c 'import krmhd; print("KRMHD imported successfully")'
           echo "✅ CUDA image verified (import-only, GPU functionality requires --gpus flag)"


### PR DESCRIPTION
## Summary
- Fixes the failing Docker GitHub Action that was preventing image verification after successful builds
- Resolves tag format mismatch between image publishing and verification steps

## Problem
The Docker workflow was failing during the "Verify published images" job with error:
```
Error response from daemon: manifest unknown
```

### Root Cause
- **Publishing step**: docker/metadata-action creates tags without 'v' prefix (e.g., 0.2.0)
- **Verification step**: Uses github.ref_name which includes 'v' prefix (e.g., v0.2.0)
- Result: Trying to pull non-existent tags causes "manifest unknown" error

## Solution
Updated both CPU and CUDA verification steps to strip the 'v' prefix from github.ref_name before using it in docker commands. The fix uses shell parameter expansion to remove the leading 'v' if present.

## Test Plan
The fix will be validated on the next tagged release. The verification step should now successfully pull and test the published images.

## Related Issues
- Failed workflow runs: v0.2.0 and v0.1.0 builds

## Impact
- Ensures Docker images are properly verified after publishing
- Prevents false-negative build failures
- Maintains consistency with semver tagging conventions