### PR TITLE
Record integrator scheme on checkpoints with mismatch warning (#142)

### DIFF
--- a/examples/benchmarks/alfvenic_cascade_benchmark.py
+++ b/examples/benchmarks/alfvenic_cascade_benchmark.py
@@ -355,7 +355,9 @@ def main():
         print(f"RESUMING FROM CHECKPOINT: {args.resume_from}")
         print("=" * 70)
 
-        resumed_state, resumed_grid, resumed_metadata = load_checkpoint(args.resume_from)
+        resumed_state, resumed_grid, resumed_metadata = load_checkpoint(
+            args.resume_from, expected_scheme="imex_rk222"
+        )
         initial_time = float(resumed_state.time)
         initial_step = int(resumed_metadata.get('step', 0))
 

--- a/examples/benchmarks/alfvenic_cascade_benchmark.py
+++ b/examples/benchmarks/alfvenic_cascade_benchmark.py
@@ -738,7 +738,7 @@ def main():
                         cfl_number=float(diag.cfl_number),
                         max_velocity=float(diag.max_velocity),
                     )
-                    save_checkpoint(state, str(checkpoint_path), metadata=checkpoint_metadata, overwrite=False)
+                    save_checkpoint(state, str(checkpoint_path), metadata=checkpoint_metadata, overwrite=False, scheme="imex_rk222")
                     print(f"  💾 Auto-saved checkpoint: {checkpoint_filename}")
 
         # Periodic checkpoint saving (by time)
@@ -760,7 +760,7 @@ def main():
                 n_force_max=n_force_max,
                 description=f'Periodic checkpoint at t={state.time:.2f} τ_A',
             )
-            save_checkpoint(state, str(checkpoint_path), metadata=checkpoint_metadata, overwrite=True)
+            save_checkpoint(state, str(checkpoint_path), metadata=checkpoint_metadata, overwrite=True, scheme="imex_rk222")
             last_checkpoint_time = state.time
             print(f"  💾 Saved periodic checkpoint (by time): {checkpoint_filename}")
 
@@ -783,7 +783,7 @@ def main():
                 n_force_max=n_force_max,
                 description=f'Periodic checkpoint at step {step}',
             )
-            save_checkpoint(state, str(checkpoint_path), metadata=checkpoint_metadata, overwrite=True)
+            save_checkpoint(state, str(checkpoint_path), metadata=checkpoint_metadata, overwrite=True, scheme="imex_rk222")
             last_checkpoint_step = step
             print(f"  💾 Saved periodic checkpoint (by steps): {checkpoint_filename}")
 
@@ -945,7 +945,7 @@ def main():
             description=f'Final checkpoint at t={state.time:.2f} τ_A (end of run)',
             total_time=float(total_time),
         )
-        save_checkpoint(state, str(checkpoint_path), metadata=checkpoint_metadata, overwrite=True)
+        save_checkpoint(state, str(checkpoint_path), metadata=checkpoint_metadata, overwrite=True, scheme="imex_rk222")
         print(f"\n💾 Saved final checkpoint: {checkpoint_filename}")
 
     # Final summary

--- a/examples/benchmarks/hermite_cascade_benchmark.py
+++ b/examples/benchmarks/hermite_cascade_benchmark.py
@@ -348,7 +348,9 @@ def main():
     if args.resume_from:
         print(f"Resuming from checkpoint: {args.resume_from}")
         try:
-            state, grid, metadata = load_checkpoint(args.resume_from)
+            state, grid, metadata = load_checkpoint(
+                args.resume_from, expected_scheme="imex_rk222"
+            )
 
             # Validate grid parameters match
             if grid.Nx != Nx or grid.Ny != Ny or grid.Nz != Nz:

--- a/examples/benchmarks/hermite_cascade_benchmark.py
+++ b/examples/benchmarks/hermite_cascade_benchmark.py
@@ -469,7 +469,7 @@ def main():
         # Save checkpoint periodically
         if step > 0 and step % checkpoint_interval == 0:
             checkpoint_filename = output_dir / f"hermite_cascade_checkpoint_step{step}_t{state.time:.1f}.h5"
-            save_checkpoint(state, str(checkpoint_filename))
+            save_checkpoint(state, str(checkpoint_filename), scheme="imex_rk222")
             print(f"  💾 Saved checkpoint: {checkpoint_filename.name}")
 
         if step % save_interval == 0:

--- a/src/krmhd/io.py
+++ b/src/krmhd/io.py
@@ -101,6 +101,7 @@ def save_checkpoint(
     filename: str,
     metadata: Optional[Dict[str, Any]] = None,
     overwrite: bool = False,
+    scheme: Optional[str] = None,
 ) -> None:
     """
     Save KRMHD state to HDF5 checkpoint file.
@@ -114,6 +115,12 @@ def save_checkpoint(
         filename: Output HDF5 file path
         metadata: Optional user metadata dict (arbitrary key-value pairs)
         overwrite: If True, overwrite existing file; otherwise raise error
+        scheme: Advisory — the gandalf_step integrator that produced this
+            state (``"imex_rk222"`` or ``"lawson_rk4"``). When provided, it
+            is written as an HDF5 metadata attribute and surfaced by
+            ``load_checkpoint`` so a resumed run can detect silent integrator
+            switches. ``None`` (default) omits the attribute; the state
+            format is unchanged.
 
     Raises:
         FileExistsError: If file exists and overwrite=False
@@ -128,7 +135,8 @@ def save_checkpoint(
         ...         "description": "Turbulence simulation",
         ...         "run_id": "turb_001",
         ...         "parameters": {"eta": 0.01, "nu": 0.01}
-        ...     }
+        ...     },
+        ...     scheme="imex_rk222",
         ... )
 
     File structure:
@@ -246,6 +254,13 @@ def save_checkpoint(
         meta_group.attrs['version'] = IO_FORMAT_VERSION
         meta_group.attrs['timestamp'] = datetime.now().isoformat()
 
+        # Advisory scheme tag (Issue #142) — consumed by load_checkpoint's
+        # expected_scheme mismatch warning. Never treated as authoritative:
+        # callers who care about reproducibility pass `scheme=` to both the
+        # save and the load side.
+        if scheme is not None:
+            meta_group.attrs['scheme'] = scheme
+
         # Add user metadata if provided
         if metadata is not None:
             for key, value in metadata.items():
@@ -260,6 +275,7 @@ def save_checkpoint(
 def load_checkpoint(
     filename: str,
     validate_grid: bool = True,
+    expected_scheme: Optional[str] = None,
 ) -> Tuple[KRMHDState, SpectralGrid3D, Dict[str, Any]]:
     """
     Load KRMHD state from HDF5 checkpoint file.
@@ -271,11 +287,20 @@ def load_checkpoint(
     Args:
         filename: Input HDF5 checkpoint file path
         validate_grid: If True, verify grid dimensions are consistent
+        expected_scheme: Optional gandalf_step scheme the caller intends to
+            resume with (``"imex_rk222"`` or ``"lawson_rk4"``). If provided
+            *and* the checkpoint was saved with a ``scheme`` tag, a
+            ``UserWarning`` is emitted when they differ — a silent switch
+            between integrators makes trajectories drift by ~1e-6/step at
+            float32 even though the Elsasser formula is scheme-independent
+            (Issue #142). ``None`` (default) skips the check for backward
+            compatibility with legacy checkpoints.
 
     Returns:
         state: Loaded KRMHD state
         grid: Reconstructed SpectralGrid3D
-        metadata: Dictionary with file metadata (version, timestamp, user data)
+        metadata: Dictionary with file metadata (version, timestamp, user
+            data, and ``scheme`` if the save side recorded one)
 
     Raises:
         FileNotFoundError: If checkpoint file doesn't exist
@@ -384,8 +409,32 @@ def load_checkpoint(
             grid=grid,
         )
 
-        # Load metadata
+        # Load metadata. The 'scheme' attribute (Issue #142) lands here
+        # automatically because it is written as an HDF5 attribute on the
+        # metadata group.
         metadata = dict(f['metadata'].attrs)
+
+    # Advisory scheme-mismatch warning (Issue #142). Only fires when the
+    # checkpoint recorded a scheme AND the caller explicitly named the
+    # scheme it intends to resume with — otherwise we stay silent so legacy
+    # checkpoints and non-opinionated callers don't get noisy.
+    stored_scheme = metadata.get('scheme')
+    if (
+        expected_scheme is not None
+        and stored_scheme is not None
+        and stored_scheme != expected_scheme
+    ):
+        warnings.warn(
+            f"Checkpoint '{filename}' was written with scheme={stored_scheme!r} "
+            f"but you requested expected_scheme={expected_scheme!r}. The z+/- "
+            f"Elsasser formula is identical under both schemes, but the two "
+            f"JIT graphs produce different float32 arithmetic orderings, so "
+            f"the resumed trajectory drifts by ~1e-6/step from the run that "
+            f"produced this checkpoint. Pass scheme=<expected_scheme> to "
+            f"gandalf_step to continue anyway, or rebuild the checkpoint "
+            f"under {expected_scheme!r} to avoid the drift.",
+            UserWarning,
+        )
 
     return state, grid, metadata
 

--- a/src/krmhd/io.py
+++ b/src/krmhd/io.py
@@ -75,7 +75,7 @@ References:
 """
 
 from pathlib import Path
-from typing import Dict, Literal, Optional, Tuple, Any
+from typing import Dict, Literal, Optional, Tuple, Any, get_args
 from datetime import datetime
 import warnings
 
@@ -443,11 +443,12 @@ def load_checkpoint(
             f"but expected_scheme={expected_scheme!r}. The Elsasser z+/- "
             f"formula is identical under both schemes, but the two JIT graphs "
             f"produce different float32 arithmetic orderings, so the resumed "
-            f"trajectory drifts by ~1e-6/step from the run that produced this "
-            f"checkpoint. To continue, call "
-            f"`gandalf_step(..., scheme={expected_scheme!r})` — the resumed "
-            f"run will diverge but remain physically valid. To avoid the "
-            f"drift entirely, rebuild the checkpoint under {expected_scheme!r}.",
+            f"trajectory will drift by ~1e-6/step from the run that produced "
+            f"this checkpoint. "
+            f"To suppress this warning and accept the drift, pin your call "
+            f"to `gandalf_step(..., scheme={expected_scheme!r})`. "
+            f"To reproduce the original trajectory, re-run the simulation "
+            f"under {stored_scheme!r} and save a fresh checkpoint.",
             UserWarning,
             stacklevel=2,
         )
@@ -456,8 +457,14 @@ def load_checkpoint(
 
 
 def _validate_scheme(scheme: str, *, kwarg_name: str) -> None:
-    """Reject typos / unknown integrators at the save/load boundary."""
-    allowed = {"imex_rk222", "lawson_rk4"}
+    """Reject typos / unknown integrators at the save/load boundary.
+
+    Derives the allow-list from the ``Scheme`` Literal at runtime via
+    ``typing.get_args`` so ``Scheme`` stays the single source of truth —
+    adding a third integrator only requires editing the Literal, not this
+    helper.
+    """
+    allowed = set(get_args(Scheme))
     if scheme not in allowed:
         raise ValueError(
             f"{kwarg_name}={scheme!r} is not a recognised gandalf_step "

--- a/src/krmhd/io.py
+++ b/src/krmhd/io.py
@@ -417,9 +417,8 @@ def load_checkpoint(
             grid=grid,
         )
 
-        # Load metadata. The 'scheme' attribute lands here automatically
-        # because it is written as an HDF5 attribute on the metadata group.
-        # Coerce bytes -> str per attribute for h5py < 3.0 compatibility.
+        # Decode every attribute, not just scheme: the bytes-vs-str quirk
+        # applies to timestamp, user metadata, etc. under h5py < 3.0 too.
         metadata = {k: _decode_attr(v) for k, v in f['metadata'].attrs.items()}
 
     # Advisory scheme-mismatch warning. Only fires when the checkpoint
@@ -434,16 +433,12 @@ def load_checkpoint(
         and stored_scheme != expected_scheme
     ):
         warnings.warn(
-            f"Checkpoint '{filename}' was written with scheme={stored_scheme!r} "
-            f"but expected_scheme={expected_scheme!r}. The Elsasser z+/- "
-            f"formula is identical under both schemes, but the two JIT graphs "
-            f"produce different float32 arithmetic orderings, so the resumed "
-            f"trajectory will drift by ~1e-6/step from the run that produced "
-            f"this checkpoint. "
-            f"To suppress this warning and accept the switch, omit "
-            f"`expected_scheme` from your `load_checkpoint` call. "
-            f"To reproduce the original trajectory, re-run the simulation "
-            f"under {stored_scheme!r} and save a fresh checkpoint.",
+            f"Checkpoint {filename!r}: stored scheme={stored_scheme!r} but "
+            f"expected_scheme={expected_scheme!r}. The Elsasser formula is "
+            f"scheme-independent but float32 arithmetic ordering differs, so "
+            f"the resumed trajectory will drift ~1e-6/step. "
+            f"To suppress: omit `expected_scheme` from your `load_checkpoint` "
+            f"call. To reproduce: re-run under {stored_scheme!r}.",
             UserWarning,
             stacklevel=2,
         )
@@ -452,12 +447,7 @@ def load_checkpoint(
 
 
 def _validate_scheme(scheme: str, *, kwarg_name: str) -> None:
-    """Reject typos / unknown integrators at the save/load boundary.
-
-    The allow-list is imported from ``krmhd.timestepping`` so there is one
-    place to edit when adding a new integrator — the Literal there drives
-    both static analysis and this runtime check.
-    """
+    """Reject typos / unknown integrators at the save/load boundary."""
     if scheme not in SUPPORTED_SCHEMES:
         raise ValueError(
             f"{kwarg_name}={scheme!r} is not a recognised gandalf_step "
@@ -466,14 +456,7 @@ def _validate_scheme(scheme: str, *, kwarg_name: str) -> None:
 
 
 def _decode_attr(value: Any) -> Any:
-    """Coerce an HDF5 attribute value back to ``str`` when it arrives as
-    ``bytes``.
-
-    h5py < 3.0 returns fixed-length string attributes as ``bytes`` rather
-    than ``str``; later versions return ``str`` by default. Normalizing
-    here keeps equality comparisons (``stored_scheme == expected_scheme``)
-    and the returned metadata dict consistent across h5py versions.
-    """
+    """Coerce bytes -> str so HDF5 string attributes round-trip as str under h5py < 3.0."""
     if isinstance(value, bytes):
         return value.decode("utf-8")
     return value

--- a/src/krmhd/io.py
+++ b/src/krmhd/io.py
@@ -75,7 +75,7 @@ References:
 """
 
 from pathlib import Path
-from typing import Dict, Literal, Optional, Tuple, Any, get_args
+from typing import Dict, Optional, Tuple, Any
 from datetime import datetime
 import warnings
 
@@ -86,6 +86,7 @@ import jax.numpy as jnp
 from krmhd.physics import KRMHDState
 from krmhd.spectral import SpectralGrid3D
 from krmhd.diagnostics import EnergyHistory, TurbulenceDiagnostics
+from krmhd.timestepping import Scheme, SUPPORTED_SCHEMES
 
 # File format version for compatibility checking
 # Increment when making breaking changes to file structure
@@ -94,13 +95,6 @@ IO_FORMAT_VERSION = "1.0.0"
 # Compression settings for HDF5 datasets
 # level 4 is a good balance between compression ratio and speed
 COMPRESSION_LEVEL = 4
-
-# Accepted values for the advisory `scheme` tag on checkpoints. Kept in sync
-# with the `scheme` kwarg on krmhd.timestepping.gandalf_step so save/load
-# can reject typos at the boundary instead of silently storing a misspelled
-# tag that would defeat the mismatch check.
-Scheme = Literal["imex_rk222", "lawson_rk4"]
-_ALLOWED_SCHEMES: frozenset[str] = frozenset(get_args(Scheme))
 
 
 def save_checkpoint(
@@ -425,7 +419,8 @@ def load_checkpoint(
 
         # Load metadata. The 'scheme' attribute lands here automatically
         # because it is written as an HDF5 attribute on the metadata group.
-        metadata = dict(f['metadata'].attrs)
+        # Coerce bytes -> str per attribute for h5py < 3.0 compatibility.
+        metadata = {k: _decode_attr(v) for k, v in f['metadata'].attrs.items()}
 
     # Advisory scheme-mismatch warning. Only fires when the checkpoint
     # recorded a scheme AND the caller explicitly named the scheme it
@@ -459,16 +454,29 @@ def load_checkpoint(
 def _validate_scheme(scheme: str, *, kwarg_name: str) -> None:
     """Reject typos / unknown integrators at the save/load boundary.
 
-    The allow-list is cached in ``_ALLOWED_SCHEMES`` and derived once at
-    import time from the ``Scheme`` Literal via ``typing.get_args`` — so
-    ``Scheme`` stays the single source of truth. Adding a third integrator
-    only requires editing the Literal.
+    The allow-list is imported from ``krmhd.timestepping`` so there is one
+    place to edit when adding a new integrator — the Literal there drives
+    both static analysis and this runtime check.
     """
-    if scheme not in _ALLOWED_SCHEMES:
+    if scheme not in SUPPORTED_SCHEMES:
         raise ValueError(
             f"{kwarg_name}={scheme!r} is not a recognised gandalf_step "
-            f"integrator. Expected one of {sorted(_ALLOWED_SCHEMES)}."
+            f"integrator. Expected one of {sorted(SUPPORTED_SCHEMES)}."
         )
+
+
+def _decode_attr(value: Any) -> Any:
+    """Coerce an HDF5 attribute value back to ``str`` when it arrives as
+    ``bytes``.
+
+    h5py < 3.0 returns fixed-length string attributes as ``bytes`` rather
+    than ``str``; later versions return ``str`` by default. Normalizing
+    here keeps equality comparisons (``stored_scheme == expected_scheme``)
+    and the returned metadata dict consistent across h5py versions.
+    """
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return value
 
 
 def save_timeseries(

--- a/src/krmhd/io.py
+++ b/src/krmhd/io.py
@@ -75,7 +75,7 @@ References:
 """
 
 from pathlib import Path
-from typing import Dict, Optional, Tuple, Any
+from typing import Dict, Literal, Optional, Tuple, Any
 from datetime import datetime
 import warnings
 
@@ -95,13 +95,19 @@ IO_FORMAT_VERSION = "1.0.0"
 # level 4 is a good balance between compression ratio and speed
 COMPRESSION_LEVEL = 4
 
+# Accepted values for the advisory `scheme` tag on checkpoints (Issue #142).
+# Kept in sync with the `scheme` kwarg on krmhd.timestepping.gandalf_step so
+# save/load can reject typos at the boundary instead of silently storing a
+# misspelled tag that would defeat the mismatch check.
+Scheme = Literal["imex_rk222", "lawson_rk4"]
+
 
 def save_checkpoint(
     state: KRMHDState,
     filename: str,
     metadata: Optional[Dict[str, Any]] = None,
     overwrite: bool = False,
-    scheme: Optional[str] = None,
+    scheme: Optional[Scheme] = None,
 ) -> None:
     """
     Save KRMHD state to HDF5 checkpoint file.
@@ -153,6 +159,11 @@ def save_checkpoint(
         Typical compression ratios are 2-5× for turbulent fields.
     """
     filepath = Path(filename)
+
+    # Validate the advisory scheme tag BEFORE touching the filesystem so a
+    # typo can't leave a partially-written file behind (Issue #142).
+    if scheme is not None:
+        _validate_scheme(scheme, kwarg_name="scheme")
 
     # Check if file exists
     if filepath.exists() and not overwrite:
@@ -254,10 +265,8 @@ def save_checkpoint(
         meta_group.attrs['version'] = IO_FORMAT_VERSION
         meta_group.attrs['timestamp'] = datetime.now().isoformat()
 
-        # Advisory scheme tag (Issue #142) — consumed by load_checkpoint's
-        # expected_scheme mismatch warning. Never treated as authoritative:
-        # callers who care about reproducibility pass `scheme=` to both the
-        # save and the load side.
+        # Advisory scheme tag (Issue #142). Validation already happened at the
+        # top of save_checkpoint so we can't silently store a typo.
         if scheme is not None:
             meta_group.attrs['scheme'] = scheme
 
@@ -275,7 +284,7 @@ def save_checkpoint(
 def load_checkpoint(
     filename: str,
     validate_grid: bool = True,
-    expected_scheme: Optional[str] = None,
+    expected_scheme: Optional[Scheme] = None,
 ) -> Tuple[KRMHDState, SpectralGrid3D, Dict[str, Any]]:
     """
     Load KRMHD state from HDF5 checkpoint file.
@@ -322,6 +331,10 @@ def load_checkpoint(
         (float32 on GPU, float32/float64 depending on JAX config on CPU).
     """
     filepath = Path(filename)
+
+    # Validate advisory kwarg up front (symmetric with save_checkpoint).
+    if expected_scheme is not None:
+        _validate_scheme(expected_scheme, kwarg_name="expected_scheme")
 
     if not filepath.exists():
         raise FileNotFoundError(f"Checkpoint file '{filename}' not found")
@@ -417,7 +430,8 @@ def load_checkpoint(
     # Advisory scheme-mismatch warning (Issue #142). Only fires when the
     # checkpoint recorded a scheme AND the caller explicitly named the
     # scheme it intends to resume with — otherwise we stay silent so legacy
-    # checkpoints and non-opinionated callers don't get noisy.
+    # checkpoints and non-opinionated callers don't get noisy. Validation
+    # of expected_scheme happened at the top of the function.
     stored_scheme = metadata.get('scheme')
     if (
         expected_scheme is not None
@@ -426,17 +440,29 @@ def load_checkpoint(
     ):
         warnings.warn(
             f"Checkpoint '{filename}' was written with scheme={stored_scheme!r} "
-            f"but you requested expected_scheme={expected_scheme!r}. The z+/- "
-            f"Elsasser formula is identical under both schemes, but the two "
-            f"JIT graphs produce different float32 arithmetic orderings, so "
-            f"the resumed trajectory drifts by ~1e-6/step from the run that "
-            f"produced this checkpoint. Pass scheme=<expected_scheme> to "
-            f"gandalf_step to continue anyway, or rebuild the checkpoint "
-            f"under {expected_scheme!r} to avoid the drift.",
+            f"but expected_scheme={expected_scheme!r}. The Elsasser z+/- "
+            f"formula is identical under both schemes, but the two JIT graphs "
+            f"produce different float32 arithmetic orderings, so the resumed "
+            f"trajectory drifts by ~1e-6/step from the run that produced this "
+            f"checkpoint. To continue, call "
+            f"`gandalf_step(..., scheme={expected_scheme!r})` — the resumed "
+            f"run will diverge but remain physically valid. To avoid the "
+            f"drift entirely, rebuild the checkpoint under {expected_scheme!r}.",
             UserWarning,
+            stacklevel=2,
         )
 
     return state, grid, metadata
+
+
+def _validate_scheme(scheme: str, *, kwarg_name: str) -> None:
+    """Reject typos / unknown integrators at the save/load boundary."""
+    allowed = {"imex_rk222", "lawson_rk4"}
+    if scheme not in allowed:
+        raise ValueError(
+            f"{kwarg_name}={scheme!r} is not a recognised gandalf_step "
+            f"integrator. Expected one of {sorted(allowed)}."
+        )
 
 
 def save_timeseries(

--- a/src/krmhd/io.py
+++ b/src/krmhd/io.py
@@ -95,11 +95,12 @@ IO_FORMAT_VERSION = "1.0.0"
 # level 4 is a good balance between compression ratio and speed
 COMPRESSION_LEVEL = 4
 
-# Accepted values for the advisory `scheme` tag on checkpoints (Issue #142).
-# Kept in sync with the `scheme` kwarg on krmhd.timestepping.gandalf_step so
-# save/load can reject typos at the boundary instead of silently storing a
-# misspelled tag that would defeat the mismatch check.
+# Accepted values for the advisory `scheme` tag on checkpoints. Kept in sync
+# with the `scheme` kwarg on krmhd.timestepping.gandalf_step so save/load
+# can reject typos at the boundary instead of silently storing a misspelled
+# tag that would defeat the mismatch check.
 Scheme = Literal["imex_rk222", "lawson_rk4"]
+_ALLOWED_SCHEMES: frozenset[str] = frozenset(get_args(Scheme))
 
 
 def save_checkpoint(
@@ -161,7 +162,7 @@ def save_checkpoint(
     filepath = Path(filename)
 
     # Validate the advisory scheme tag BEFORE touching the filesystem so a
-    # typo can't leave a partially-written file behind (Issue #142).
+    # typo can't leave a partially-written file behind.
     if scheme is not None:
         _validate_scheme(scheme, kwarg_name="scheme")
 
@@ -265,8 +266,8 @@ def save_checkpoint(
         meta_group.attrs['version'] = IO_FORMAT_VERSION
         meta_group.attrs['timestamp'] = datetime.now().isoformat()
 
-        # Advisory scheme tag (Issue #142). Validation already happened at the
-        # top of save_checkpoint so we can't silently store a typo.
+        # Advisory scheme tag. Validation already happened at the top of
+        # save_checkpoint so we can't silently store a typo.
         if scheme is not None:
             meta_group.attrs['scheme'] = scheme
 
@@ -301,9 +302,9 @@ def load_checkpoint(
             *and* the checkpoint was saved with a ``scheme`` tag, a
             ``UserWarning`` is emitted when they differ — a silent switch
             between integrators makes trajectories drift by ~1e-6/step at
-            float32 even though the Elsasser formula is scheme-independent
-            (Issue #142). ``None`` (default) skips the check for backward
-            compatibility with legacy checkpoints.
+            float32 even though the Elsasser formula is scheme-independent.
+            ``None`` (default) skips the check for backward compatibility
+            with legacy checkpoints.
 
     Returns:
         state: Loaded KRMHD state
@@ -422,16 +423,15 @@ def load_checkpoint(
             grid=grid,
         )
 
-        # Load metadata. The 'scheme' attribute (Issue #142) lands here
-        # automatically because it is written as an HDF5 attribute on the
-        # metadata group.
+        # Load metadata. The 'scheme' attribute lands here automatically
+        # because it is written as an HDF5 attribute on the metadata group.
         metadata = dict(f['metadata'].attrs)
 
-    # Advisory scheme-mismatch warning (Issue #142). Only fires when the
-    # checkpoint recorded a scheme AND the caller explicitly named the
-    # scheme it intends to resume with — otherwise we stay silent so legacy
-    # checkpoints and non-opinionated callers don't get noisy. Validation
-    # of expected_scheme happened at the top of the function.
+    # Advisory scheme-mismatch warning. Only fires when the checkpoint
+    # recorded a scheme AND the caller explicitly named the scheme it
+    # intends to resume with — otherwise stay silent so legacy checkpoints
+    # and non-opinionated callers don't get noisy. Validation of
+    # expected_scheme happened at the top of the function.
     stored_scheme = metadata.get('scheme')
     if (
         expected_scheme is not None
@@ -445,8 +445,8 @@ def load_checkpoint(
             f"produce different float32 arithmetic orderings, so the resumed "
             f"trajectory will drift by ~1e-6/step from the run that produced "
             f"this checkpoint. "
-            f"To suppress this warning and accept the drift, pin your call "
-            f"to `gandalf_step(..., scheme={expected_scheme!r})`. "
+            f"To suppress this warning and accept the switch, omit "
+            f"`expected_scheme` from your `load_checkpoint` call. "
             f"To reproduce the original trajectory, re-run the simulation "
             f"under {stored_scheme!r} and save a fresh checkpoint.",
             UserWarning,
@@ -459,16 +459,15 @@ def load_checkpoint(
 def _validate_scheme(scheme: str, *, kwarg_name: str) -> None:
     """Reject typos / unknown integrators at the save/load boundary.
 
-    Derives the allow-list from the ``Scheme`` Literal at runtime via
-    ``typing.get_args`` so ``Scheme`` stays the single source of truth —
-    adding a third integrator only requires editing the Literal, not this
-    helper.
+    The allow-list is cached in ``_ALLOWED_SCHEMES`` and derived once at
+    import time from the ``Scheme`` Literal via ``typing.get_args`` — so
+    ``Scheme`` stays the single source of truth. Adding a third integrator
+    only requires editing the Literal.
     """
-    allowed = set(get_args(Scheme))
-    if scheme not in allowed:
+    if scheme not in _ALLOWED_SCHEMES:
         raise ValueError(
             f"{kwarg_name}={scheme!r} is not a recognised gandalf_step "
-            f"integrator. Expected one of {sorted(allowed)}."
+            f"integrator. Expected one of {sorted(_ALLOWED_SCHEMES)}."
         )
 
 

--- a/src/krmhd/timestepping.py
+++ b/src/krmhd/timestepping.py
@@ -34,7 +34,7 @@ References:
 import math
 import warnings
 from functools import partial
-from typing import Callable, Literal, Tuple, NamedTuple
+from typing import Callable, Literal, Tuple, NamedTuple, get_args
 
 import jax
 import jax.numpy as jnp
@@ -623,13 +623,12 @@ def _gandalf_step_lawson_rk4_jit(
 # IMEX-RK222 Hermite Integrator (Issue #137)
 # =============================================================================
 
-# Public allow-list of integrator schemes accepted by gandalf_step(). The
-# Literal below is the source of truth for static analysis; SUPPORTED_SCHEMES
-# is the runtime-introspectable frozenset derived from it. Other modules
-# (krmhd.io) import both so there is one place to edit when adding a new
-# integrator.
+# Public allow-list of integrator schemes accepted by gandalf_step().
+# `Scheme` is the single source of truth; `SUPPORTED_SCHEMES` is the
+# runtime-introspectable frozenset derived from it so adding a new
+# integrator is a one-line edit.
 Scheme = Literal["imex_rk222", "lawson_rk4"]
-SUPPORTED_SCHEMES: frozenset[str] = frozenset(("imex_rk222", "lawson_rk4"))
+SUPPORTED_SCHEMES: frozenset[str] = frozenset(get_args(Scheme))
 
 # ARS(2,2,2) implicit-stage coefficient and stage-2 explicit scaling (Python floats).
 # Note delta is NEGATIVE (~ -0.7071); the dt*delta*N_1 contribution in

--- a/src/krmhd/timestepping.py
+++ b/src/krmhd/timestepping.py
@@ -623,6 +623,14 @@ def _gandalf_step_lawson_rk4_jit(
 # IMEX-RK222 Hermite Integrator (Issue #137)
 # =============================================================================
 
+# Public allow-list of integrator schemes accepted by gandalf_step(). The
+# Literal below is the source of truth for static analysis; SUPPORTED_SCHEMES
+# is the runtime-introspectable frozenset derived from it. Other modules
+# (krmhd.io) import both so there is one place to edit when adding a new
+# integrator.
+Scheme = Literal["imex_rk222", "lawson_rk4"]
+SUPPORTED_SCHEMES: frozenset[str] = frozenset(("imex_rk222", "lawson_rk4"))
+
 # ARS(2,2,2) implicit-stage coefficient and stage-2 explicit scaling (Python floats).
 # Note delta is NEGATIVE (~ -0.7071); the dt*delta*N_1 contribution in
 # stage B's RHS therefore *subtracts* the initial-state nonlinear evaluation.
@@ -880,7 +888,7 @@ def gandalf_step(
     nu: float | None = None,
     hyper_r: int = 1,
     hyper_n: int = 1,
-    scheme: Literal["imex_rk222", "lawson_rk4"] = "imex_rk222",
+    scheme: Scheme = "imex_rk222",
 ) -> KRMHDState:
     """
     Advance KRMHD state using the mixed GANDALF integrating-factor method.

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -341,6 +341,33 @@ def test_checkpoint_load_rejects_unknown_expected_scheme(state, tmpdir):
         load_checkpoint(str(filename), expected_scheme="foo")
 
 
+def test_checkpoint_scheme_tag_survives_bytes_attr(state, tmpdir):
+    """h5py < 3.0 (and some edge cases in 3.x with vlen_string=False) return
+    fixed-length string attributes as `bytes`. The mismatch check must still
+    fire in that case: `stored_scheme = b"lawson_rk4"` is not equal to the
+    str `"imex_rk222"`, so without the bytes-decode helper we would silently
+    miss the mismatch."""
+    filename = tmpdir / "ckpt_bytes.h5"
+    save_checkpoint(state, str(filename), scheme="lawson_rk4")
+
+    # Simulate the h5py < 3.0 path: reopen the file and rewrite the scheme
+    # attribute as a fixed-length (= bytes-returning) string.
+    with h5py.File(str(filename), "a") as f:
+        del f["metadata"].attrs["scheme"]
+        f["metadata"].attrs.create(
+            "scheme",
+            data=b"lawson_rk4",
+            dtype=h5py.string_dtype(encoding="utf-8", length=10),
+        )
+
+    with pytest.warns(UserWarning, match="lawson_rk4.*imex_rk222"):
+        _, _, metadata = load_checkpoint(str(filename), expected_scheme="imex_rk222")
+    # And the returned metadata should have a plain str, not bytes, so
+    # downstream code can use it without further coercion.
+    assert metadata["scheme"] == "lawson_rk4"
+    assert isinstance(metadata["scheme"], str)
+
+
 def test_checkpoint_mismatch_warning_remediation_text(state, tmpdir):
     """The warning must name a remediation that actually suppresses it.
     Suppressing requires either omitting expected_scheme or re-saving the

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -15,6 +15,7 @@ Test organization:
 """
 
 import tempfile
+import warnings
 from pathlib import Path
 import pytest
 import numpy as np
@@ -295,9 +296,8 @@ def test_checkpoint_scheme_match_silent(state, tmpdir):
     filename = tmpdir / "ckpt_match.h5"
     save_checkpoint(state, str(filename), scheme="imex_rk222")
 
-    import warnings as _warnings
-    with _warnings.catch_warnings():
-        _warnings.simplefilter("error")  # Turn warnings into errors for this block
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # Turn warnings into errors for this block
         load_checkpoint(str(filename), expected_scheme="imex_rk222")
 
 
@@ -307,9 +307,8 @@ def test_checkpoint_legacy_no_stored_scheme_silent(state, tmpdir):
     filename = tmpdir / "ckpt_legacy.h5"
     save_checkpoint(state, str(filename))  # no scheme=
 
-    import warnings as _warnings
-    with _warnings.catch_warnings():
-        _warnings.simplefilter("error")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         load_checkpoint(str(filename), expected_scheme="imex_rk222")
 
 
@@ -319,10 +318,46 @@ def test_checkpoint_expected_scheme_none_silent(state, tmpdir):
     filename = tmpdir / "ckpt_expected_none.h5"
     save_checkpoint(state, str(filename), scheme="lawson_rk4")
 
-    import warnings as _warnings
-    with _warnings.catch_warnings():
-        _warnings.simplefilter("error")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         load_checkpoint(str(filename))  # no expected_scheme
+
+
+def test_checkpoint_save_rejects_unknown_scheme(state, tmpdir):
+    """A typo in `scheme` is caught at save time, not silently stored."""
+    filename = tmpdir / "ckpt_bad_save.h5"
+    with pytest.raises(ValueError, match="scheme='imex_rk22'"):
+        save_checkpoint(state, str(filename), scheme="imex_rk22")  # typo
+    # And the file is never created.
+    assert not filename.exists()
+
+
+def test_checkpoint_load_rejects_unknown_expected_scheme(state, tmpdir):
+    """A typo in `expected_scheme` is caught at load time, before the
+    mismatch check runs (symmetric with save-side validation)."""
+    filename = tmpdir / "ckpt_bad_load.h5"
+    save_checkpoint(state, str(filename), scheme="imex_rk222")
+    with pytest.raises(ValueError, match="expected_scheme='foo'"):
+        load_checkpoint(str(filename), expected_scheme="foo")
+
+
+def test_checkpoint_mismatch_warning_points_to_caller(state, tmpdir):
+    """stacklevel=2 ensures the warning's source location names the
+    caller's frame, not io.py. A missing stacklevel was the blocker from
+    review round 1 on #143."""
+    filename = tmpdir / "ckpt_stacklevel.h5"
+    save_checkpoint(state, str(filename), scheme="lawson_rk4")
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        load_checkpoint(str(filename), expected_scheme="imex_rk222")
+
+    assert len(w) == 1
+    # The recorded warning should point at THIS test file (the caller),
+    # not the io.py module that issued the warning.
+    assert w[0].filename.endswith("test_io.py"), (
+        f"warning filename {w[0].filename!r} is not the caller frame"
+    )
 
 
 # =============================================================================

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -258,6 +258,74 @@ def test_checkpoint_grid_reconstruction(state, tmpdir):
 
 
 # =============================================================================
+# Scheme tag on checkpoints (Issue #142)
+# =============================================================================
+
+
+def test_checkpoint_scheme_tag_written(state, tmpdir):
+    """When `scheme=` is passed to save_checkpoint, it lands in metadata."""
+    filename = tmpdir / "ckpt_scheme.h5"
+    save_checkpoint(state, str(filename), scheme="imex_rk222")
+
+    _, _, metadata = load_checkpoint(str(filename))
+    assert metadata.get("scheme") == "imex_rk222"
+
+
+def test_checkpoint_scheme_tag_absent_by_default(state, tmpdir):
+    """Without `scheme=`, the attribute is NOT written (legacy compat)."""
+    filename = tmpdir / "ckpt_no_scheme.h5"
+    save_checkpoint(state, str(filename))
+
+    _, _, metadata = load_checkpoint(str(filename))
+    assert "scheme" not in metadata
+
+
+def test_checkpoint_scheme_mismatch_warns(state, tmpdir):
+    """Loading with expected_scheme that differs from the stored scheme
+    emits a UserWarning naming both schemes."""
+    filename = tmpdir / "ckpt_mismatch.h5"
+    save_checkpoint(state, str(filename), scheme="lawson_rk4")
+
+    with pytest.warns(UserWarning, match="lawson_rk4.*imex_rk222"):
+        load_checkpoint(str(filename), expected_scheme="imex_rk222")
+
+
+def test_checkpoint_scheme_match_silent(state, tmpdir):
+    """Matching schemes do not emit a warning."""
+    filename = tmpdir / "ckpt_match.h5"
+    save_checkpoint(state, str(filename), scheme="imex_rk222")
+
+    import warnings as _warnings
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error")  # Turn warnings into errors for this block
+        load_checkpoint(str(filename), expected_scheme="imex_rk222")
+
+
+def test_checkpoint_legacy_no_stored_scheme_silent(state, tmpdir):
+    """Legacy checkpoints (no scheme attribute) emit no warning, even when
+    expected_scheme is provided. Silence is the backward-compat contract."""
+    filename = tmpdir / "ckpt_legacy.h5"
+    save_checkpoint(state, str(filename))  # no scheme=
+
+    import warnings as _warnings
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error")
+        load_checkpoint(str(filename), expected_scheme="imex_rk222")
+
+
+def test_checkpoint_expected_scheme_none_silent(state, tmpdir):
+    """Default expected_scheme=None skips the check entirely, even when a
+    scheme is stored. Non-opinionated callers stay quiet."""
+    filename = tmpdir / "ckpt_expected_none.h5"
+    save_checkpoint(state, str(filename), scheme="lawson_rk4")
+
+    import warnings as _warnings
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error")
+        load_checkpoint(str(filename))  # no expected_scheme
+
+
+# =============================================================================
 # Timeseries Tests
 # =============================================================================
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -259,7 +259,7 @@ def test_checkpoint_grid_reconstruction(state, tmpdir):
 
 
 # =============================================================================
-# Scheme tag on checkpoints (Issue #142)
+# Scheme tag on checkpoints
 # =============================================================================
 
 
@@ -341,10 +341,30 @@ def test_checkpoint_load_rejects_unknown_expected_scheme(state, tmpdir):
         load_checkpoint(str(filename), expected_scheme="foo")
 
 
+def test_checkpoint_mismatch_warning_remediation_text(state, tmpdir):
+    """The warning must name a remediation that actually suppresses it.
+    Suppressing requires either omitting expected_scheme or re-saving the
+    checkpoint; pinning gandalf_step has zero effect on load_checkpoint
+    behaviour."""
+    filename = tmpdir / "ckpt_remediation_text.h5"
+    save_checkpoint(state, str(filename), scheme="lawson_rk4")
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        load_checkpoint(str(filename), expected_scheme="imex_rk222")
+
+    assert len(w) == 1
+    msg = str(w[0].message)
+    # Correct remediation is named verbatim.
+    assert "omit" in msg and "expected_scheme" in msg and "load_checkpoint" in msg
+    # And the misleading old phrasing ("pin gandalf_step") must NOT appear.
+    assert "pin your call to `gandalf_step" not in msg
+
+
 def test_checkpoint_mismatch_warning_points_to_caller(state, tmpdir):
     """stacklevel=2 ensures the warning's source location names the
-    caller's frame, not io.py. A missing stacklevel was the blocker from
-    review round 1 on #143."""
+    caller's frame, not io.py. Without it, a mismatched diagnostic looks
+    like it came from inside the library, which is unhelpful for triage."""
     filename = tmpdir / "ckpt_stacklevel.h5"
     save_checkpoint(state, str(filename), scheme="lawson_rk4")
 


### PR DESCRIPTION
## Summary
- `save_checkpoint(..., scheme=<name>)` writes the gandalf_step integrator used to produce the state as an advisory HDF5 attribute under `/metadata/scheme`. When omitted, no attribute is written — legacy checkpoints and non-opinionated callers stay unchanged.
- `load_checkpoint(..., expected_scheme=<name>)` compares the stored tag against the caller's intent. Mismatch → `UserWarning` naming both schemes and suggesting the remediation. No tag stored OR `expected_scheme=None` → silent.
- Closes #142.

### Why
After PR #138 flipped the `gandalf_step` default from `"lawson_rk4"` to `"imex_rk222"`, a checkpoint written before the flip and resumed after it without an explicit `scheme=` pin silently switches integrators. The Elsasser formula is mathematically identical under both schemes (z+/- RHS does not take g), but the two JIT graphs produce different float32 arithmetic orderings, so the resumed trajectory drifts ~1e-6/step from the run that produced the checkpoint.

### Design choice
Option B from #142 (HDF5 sidecar metadata, not a `KRMHDState` field). `KRMHDState` stays purely physics; the advisory lives with the checkpoint file where it belongs. No runtime cost on the fast path.

## Test plan
- [x] `uv run pytest tests/test_io.py -k checkpoint` — 21/21 green, includes 6 new scheme-tag tests
- [x] `uv run pytest tests/test_io.py` — 33 pass + 4 pre-existing `test_turbulence_diagnostics_*` failures unrelated to this PR
- [ ] Smoke-test manual save → load roundtrip with `scheme="imex_rk222"` and verify metadata round-trips