### PR TITLE
Fix factor-2 error in Elsasser nonlinearity

### DIFF
--- a/src/krmhd/physics.py
+++ b/src/krmhd/physics.py
@@ -710,10 +710,10 @@ def z_plus_rhs(
     This matches the original GANDALF Fortran/CUDA implementation from nonlin.cu:
         bracket1 = {z⁺, -k⊥²z⁻} + {z⁻, -k⊥²z⁺}
         bracket2 = -k⊥²{z⁺, z⁻}
-        RHS_nonlinear = k⊥²^(-1) × [bracket1 - bracket2]
+        RHS_nonlinear = (1/2) k⊥²^(-1) × [bracket1 - bracket2]
 
     Which expands to:
-        ∂z⁺/∂t = k⊥²^(-1)[{z⁺, -k⊥²z⁻} + {z⁻, -k⊥²z⁺} + k⊥²{z⁺, z⁻}] + ∂∥z⁺ + η∇²z⁺
+        ∂z⁺/∂t = (1/2)k⊥²^(-1)[{z⁺, -k⊥²z⁻} + {z⁻, -k⊥²z⁺} + k⊥²{z⁺, z⁻}] + ∂∥z⁺ + η∇²z⁺
 
     Note: Linear term is +ikz·z⁺ (UNCOUPLED - same variable, not opposite!)
 
@@ -732,7 +732,11 @@ def z_plus_rhs(
         Time derivative ∂z⁺/∂t in Fourier space
 
     Reference:
-        Original GANDALF: nonlin.cu and timestep.cu (alf_adv function)
+        Original GANDALF: nonlin.cu and timestep.cu (alf_adv function).
+        The (1/2) on the nonlinear term is applied inside the original
+        GANDALF's inverse-Laplacian kernel multKPerpInv (work_kernel.cu:39,
+        `.5f * f[index] * kPerp2Inv`), even though nonlin.cu itself shows
+        no factor — see the comment at timestep.cu:10.
     """
     # Compute perpendicular Laplacian terms
     lap_perp_z_plus = laplacian(z_plus, kx, ky, kz=None)   # -k⊥²z⁺
@@ -772,7 +776,9 @@ def z_plus_rhs(
 
     # Assemble RHS: ∂z⁺/∂t = ... + ikz·z⁺
     # Note: -inv_laplacian because laplacian() returns -k²f, need negative to get +k⁻²·[...]
-    rhs = -inv_laplacian + parallel_grad_z_plus
+    # The 0.5 is the (1/2) in front of the Elsasser nonlinearity; in the
+    # original GANDALF it lives inside multKPerpInv (work_kernel.cu:39)
+    rhs = -0.5 * inv_laplacian + parallel_grad_z_plus
 
     # Add dissipation
     lap_z_plus = laplacian(z_plus, kx, ky, kz)
@@ -802,7 +808,7 @@ def z_minus_rhs(
 
     This matches the original GANDALF Fortran/CUDA implementation.
     For z⁻, the signs differ from z⁺ in the parallel gradient term:
-        ∂z⁻/∂t = k⊥²^(-1)[{z⁻, -k⊥²z⁺} + {z⁺, -k⊥²z⁻} + k⊥²{z⁻, z⁺}] - ∂∥z⁻ + η∇²z⁻
+        ∂z⁻/∂t = (1/2)k⊥²^(-1)[{z⁻, -k⊥²z⁺} + {z⁺, -k⊥²z⁻} + k⊥²{z⁻, z⁺}] - ∂∥z⁻ + η∇²z⁻
 
     Note: Linear term is -ikz·z⁻ (UNCOUPLED - same variable, not opposite!)
     (Opposite sign on parallel gradient compared to z⁺)
@@ -819,7 +825,11 @@ def z_minus_rhs(
         Time derivative ∂z⁻/∂t in Fourier space
 
     Reference:
-        Original GANDALF: nonlin.cu and timestep.cu (alf_adv function)
+        Original GANDALF: nonlin.cu and timestep.cu (alf_adv function).
+        The (1/2) on the nonlinear term is applied inside the original
+        GANDALF's inverse-Laplacian kernel multKPerpInv (work_kernel.cu:39,
+        `.5f * f[index] * kPerp2Inv`), even though nonlin.cu itself shows
+        no factor — see the comment at timestep.cu:10.
     """
     # Compute perpendicular Laplacian terms
     lap_perp_z_plus = laplacian(z_plus, kx, ky, kz=None)
@@ -855,7 +865,9 @@ def z_minus_rhs(
 
     # Assemble RHS: ∂z⁻/∂t = ... - ikz·z⁻
     # Note: -inv_laplacian because laplacian() returns -k²f, need negative to get +k⁻²·[...]
-    rhs = -inv_laplacian - parallel_grad_z_minus
+    # The 0.5 is the (1/2) in front of the Elsasser nonlinearity; in the
+    # original GANDALF it lives inside multKPerpInv (work_kernel.cu:39)
+    rhs = -0.5 * inv_laplacian - parallel_grad_z_minus
 
     # Add dissipation
     lap_z_minus = laplacian(z_minus, kx, ky, kz)

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -1793,6 +1793,113 @@ class TestElsasserRHS:
         assert relative_dissipation < 10.0, \
             f"Dissipation unreasonably strong: |dE/dt|/E = {relative_dissipation} (expected < 10.0)"
 
+    def test_elsasser_nonlinearity_matches_primitive_rmhd(self):
+        """
+        Regression test: Elsasser nonlinearity must equal the primitive
+        (φ, Ψ) vorticity/induction form, including the overall factor 1/2.
+
+        Derivation sketch (v_A = 1, ζ± = φ ± Ψ, w = ∇⊥²φ, j = ∇⊥²Ψ):
+            Vorticity:  ∂w/∂t = -{φ, w} + {Ψ, j} + ∂z j
+            Induction:  ∂Ψ/∂t = -{φ, Ψ} + ∂z φ
+        Apply ∇⊥² to the induction equation: ∂j/∂t = -∇⊥²{φ, Ψ} + ∂z w.
+        Then ∂(∇⊥²ζ±)/∂t = ∂w/∂t ± ∂j/∂t gives
+            ∂ζ±/∂t = ±∂z ζ± + ∇⊥⁻²[-{φ, w} + {Ψ, j} ∓ ∇⊥²{φ, Ψ}]
+
+        Substituting φ = (z⁺+z⁻)/2, Ψ = (z⁺-z⁻)/2 and expanding the brackets
+        shows the code's combined-bracket form must carry a factor 1/2:
+            ∂z±/∂t = ±∂z z± - (1/2)∇⊥⁻²[{z⁺,∇⊥²z⁻} + {z⁻,∇⊥²z⁺} ∓ ∇⊥²{z⁺,z⁻}]
+
+        The original CUDA GANDALF applies this 0.5 inside its inverse-Laplacian
+        kernel (work_kernel.cu:39: `.5f * f[index] * kPerp2Inv(idx,idy)`), as
+        noted in timestep.cu:10, even though nonlin.cu itself shows no factor.
+        A missing 0.5 doubles the nonlinear cascade rate while still conserving
+        energy exactly, so energy-conservation and linear-dispersion tests
+        cannot detect it -- only this direct comparison can. On code missing
+        the 1/2, the relative residual below is exactly 1.0 (code = 2x truth).
+        """
+        from krmhd.physics import z_plus_rhs, z_minus_rhs
+        from krmhd.spectral import derivative_z, laplacian
+
+        grid = SpectralGrid3D.create(Nx=32, Ny=32, Nz=16)
+
+        # Band-limited random fields (|kx|<=3, |ky|<=3, |kz|<=2) so that all
+        # quadratic products stay strictly inside the 2/3 dealiasing boundary
+        # and the comparison is free of dealiasing/truncation artifacts.
+        kx3d = grid.kx[jnp.newaxis, jnp.newaxis, :]
+        ky3d = grid.ky[jnp.newaxis, :, jnp.newaxis]
+        kz3d = grid.kz[:, jnp.newaxis, jnp.newaxis]
+        band_mask = (
+            (jnp.abs(kx3d) <= 3) & (jnp.abs(ky3d) <= 3) & (jnp.abs(kz3d) <= 2)
+        )
+
+        shape = (grid.Nz, grid.Ny, grid.Nx // 2 + 1)
+        key = jax.random.PRNGKey(7)
+        k1, k2, k3, k4 = jax.random.split(key, 4)
+        z_plus = (
+            (jax.random.normal(k1, shape) + 1j * jax.random.normal(k2, shape))
+            * band_mask
+        ).astype(jnp.complex64)
+        z_minus = (
+            (jax.random.normal(k3, shape) + 1j * jax.random.normal(k4, shape))
+            * band_mask
+        ).astype(jnp.complex64)
+        z_plus = z_plus.at[0, 0, 0].set(0.0 + 0.0j)
+        z_minus = z_minus.at[0, 0, 0].set(0.0 + 0.0j)
+
+        # Nonlinear part of the code's RHS (eta=0; strip the linear ±ikz term)
+        nl_code_p = z_plus_rhs(
+            z_plus, z_minus, grid.kx, grid.ky, grid.kz, grid.dealias_mask,
+            0.0, grid.Nz, grid.Ny, grid.Nx,
+        ) - derivative_z(z_plus, grid.kz)
+        nl_code_m = z_minus_rhs(
+            z_plus, z_minus, grid.kx, grid.ky, grid.kz, grid.dealias_mask,
+            0.0, grid.Nz, grid.Ny, grid.Nx,
+        ) + derivative_z(z_minus, grid.kz)
+
+        # Independent assembly of the same nonlinearity from primitive fields
+        phi = (z_plus + z_minus) / 2.0
+        psi = (z_plus - z_minus) / 2.0
+        w = laplacian(phi, grid.kx, grid.ky, kz=None)  # vorticity ∇⊥²φ
+        j = laplacian(psi, grid.kx, grid.ky, kz=None)  # current   ∇⊥²Ψ
+
+        def pb(f, g):
+            return poisson_bracket_3d(
+                f, g, grid.kx, grid.ky, grid.Nz, grid.Ny, grid.Nx,
+                grid.dealias_mask,
+            )
+
+        lap_pb_phi_psi = laplacian(pb(phi, psi), grid.kx, grid.ky, kz=None)
+        num_plus = (-pb(phi, w) + pb(psi, j)) + (-lap_pb_phi_psi)
+        num_minus = (-pb(phi, w) + pb(psi, j)) - (-lap_pb_phi_psi)
+
+        # Apply ∇⊥⁻² (multiply by -1/k⊥²; k⊥=0 column does not evolve)
+        k_perp2 = kx3d**2 + ky3d**2
+        k_perp2_safe = jnp.where(k_perp2 == 0, 1.0, k_perp2)
+        nl_prim_p = jnp.where(
+            k_perp2 == 0, 0.0 + 0.0j, num_plus / (-k_perp2_safe)
+        )
+        nl_prim_m = jnp.where(
+            k_perp2 == 0, 0.0 + 0.0j, num_minus / (-k_perp2_safe)
+        )
+
+        res_p = (
+            jnp.linalg.norm(nl_code_p - nl_prim_p) / jnp.linalg.norm(nl_prim_p)
+        )
+        res_m = (
+            jnp.linalg.norm(nl_code_m - nl_prim_m) / jnp.linalg.norm(nl_prim_m)
+        )
+
+        assert res_p < 1e-4, (
+            f"z_plus nonlinearity disagrees with primitive RMHD form: relative "
+            f"residual {res_p:.6f} (residual ~1.0 means the code term is "
+            f"exactly 2x the correct one, i.e. the factor 1/2 is missing)"
+        )
+        assert res_m < 1e-4, (
+            f"z_minus nonlinearity disagrees with primitive RMHD form: relative "
+            f"residual {res_m:.6f} (residual ~1.0 means the code term is "
+            f"exactly 2x the correct one, i.e. the factor 1/2 is missing)"
+        )
+
 
 # ==============================================================================
 # Hermite Moment RHS Tests


### PR DESCRIPTION
## Summary

The Elsasser nonlinear term in `z_plus_rhs` / `z_minus_rhs` (`src/krmhd/physics.py`) was exactly **2x too large**: the JAX port reproduced the bracket structure from the original GANDALF's `nonlin.cu` but missed the factor 1/2 that the original applies inside its inverse-Laplacian kernel. This PR adds a regression test that pins the nonlinearity to the primitive-variable RMHD form (written first, TDD-style, and confirmed failing with relative residual exactly 1.000000 on unfixed code), then applies the one-line fix in each RHS.

## The correct equations

In Elsasser potentials (v_A = 1, ζ± = φ ± Ψ, u = ẑ×∇φ, b = ẑ×∇Ψ), the RMHD equations are

```
∂ζ±/∂t = ±∂z ζ± − (1/2) ∇⊥⁻² [ {z⁺, ∇⊥²z⁻} + {z⁻, ∇⊥²z⁺} ∓ ∇⊥²{z⁺, z⁻} ]
```

derivable from the vorticity + induction equations:

```
∂w/∂t = −{φ, w} + {Ψ, j} + ∂z j      (w = ∇⊥²φ, j = ∇⊥²Ψ)
∂Ψ/∂t = −{φ, Ψ} + ∂z φ               (apply ∇⊥², add/subtract)
```

Substituting φ = (z⁺+z⁻)/2, Ψ = (z⁺−z⁻)/2 into the combined-bracket form produces an overall factor 2 that must be cancelled by the (1/2). The code computed the bracket combination without it.

## Evidence from the original CUDA GANDALF

- `work_kernel.cu:39` (the `multKPerpInv` kernel): `fK[index] = .5f * f[index] * kPerp2Inv(idx,idy);` — the 0.5 lives inside the inverse-Laplacian kernel.
- `timestep.cu:10` (in `alf_adv`): `// Coeff of 0.5 in front of the nonlinear term is included in multkperpinv`.

The JAX port faithfully reproduced the bracket structure from `nonlin.cu` (which shows no factor) but missed the 0.5 hidden in the kernel.

## Numerical verification

Assembling the nonlinear RHS independently from the primitive (φ, Ψ) vorticity/induction form and comparing against `z_plus_rhs` minus its linear term gives a ratio of exactly **2.000000** (residual ~3.5e-6, float32 roundoff); same for `z_minus_rhs`. After the fix, the new regression test `test_elsasser_nonlinearity_matches_primitive_rmhd` passes with residual at float32 roundoff.

## Why no existing test caught this

- **Energy conservation** holds for *any* constant multiple of this term (the bracket combination is antisymmetric regardless of prefactor).
- **Linear dispersion tests** have no nonlinearity.
- The **grid convergence test** uses a single Alfvén wave whose self-bracket vanishes identically.
- **2D Orszag-Tang** with a doubled nonlinearity produces the *identical* trajectory traversed at exactly 2x speed (pure time rescaling in 2D), so snapshots at matched "times" look plausible.

## Consequences of the bug (and of fixing it)

- **Alfvén-only (fluid) runs**: the error is a field rescaling z → 2z (equivalently a 2x time-rescale for 2D Orszag-Tang), so prior qualitative results are salvageable by reinterpretation.
- **Kinetic runs**: a genuine inconsistency, not a rescaling — φ advects the Hermite moments g with coefficient 1 while z± effectively self-advected at 2x. This biases critical balance and the phase-mixing vs. nonlinear-decorrelation ratios, so kinetic results (Landau damping rates in turbulence, Hermite spectra) were quantitatively distorted.
- **Calibrated parameter tables shift**: all empirically calibrated forcing amplitudes / η tables — including the blowup-time table in #136 — were tuned against the doubled nonlinearity. Saturation amplitudes, cascade rates, and blowup thresholds will change after this fix; those calibrations should be redone.

Related to #136 and #75 — the quantitative FDT validation (#75) needs this fixed first, since the fluctuation-dissipation balance depends on the true nonlinear transfer rate.

## Recommendation

Since nonlinear trajectories change for every user (checkpoint continuations included), recommend a **minor version bump** (0.5.0 → 0.6.0) rather than a patch release.

## Test plan

- New regression test `tests/test_physics.py::TestElsasserRHS::test_elsasser_nonlinearity_matches_primitive_rmhd`:
  - Written FIRST and confirmed FAILING on unfixed code with relative residual exactly 1.000000 (code = 2x truth) for both z⁺ and z⁻.
  - Passes after the fix (residual < 1e-4, actual ~1e-6, float32 roundoff).
- Full suite (`uv run pytest tests/ -q --ignore=tests/test_modal.py --ignore=tests/test_performance.py`, with `tests/test_examples.py` run separately): **614 passed, 1 skipped, 12 failed — all 12 failures are pre-existing on main** (verified by stashing this change and rerunning them on the unmodified tree: identical failure set).
  - Pre-existing failures, unrelated to this change:
    - `tests/test_io.py` (4): `test_turbulence_diagnostics_{roundtrip,metadata_preservation,empty_list,compression}` — TypeError / IndexError / compression-size assertion in the diagnostics I/O path.
    - `tests/test_physics.py::TestKRMHDState::test_energy_parseval_validation` (1) — Parseval energy assertion; involves only `initialize_alfven_wave` + `energy()`, not the RHS.
    - `tests/test_run_simulation.py` (7) — all cascade from `UnboundLocalError: cannot access local variable 'np'` at `scripts/run_simulation.py:306`.
- **No test expectations needed adjustment** for the factor change — no existing assertion was calibrated against the doubled nonlinearity tightly enough to break (which is itself a symptom of why the bug survived).
