### PR TITLE
CFL: account for Elsasser and field-line advection speeds

### DIFF
--- a/src/krmhd/timestepping.py
+++ b/src/krmhd/timestepping.py
@@ -1181,9 +1181,15 @@ def compute_cfl_timestep(
     The CFL (Courant-Friedrichs-Lewy) condition ensures numerical stability
     by requiring that information propagates at most one grid cell per timestep:
 
-        dt ≤ C * min(Δx, Δy, Δz) / max(v_A, |v_⊥|)
+        dt ≤ C * min(Δx, Δy, Δz) / v_max
 
-    where C is a safety factor (typically 0.1-0.5 for RK2/RK4).
+    where C is a safety factor (typically 0.1-0.5 for RK2/RK4) and v_max is
+    the maximum signal speed in the system:
+
+        v_max = max(v_A, max|∇⊥z⁺|, max|∇⊥z⁻|, √β_i · max|∇⊥Ψ|)
+
+    with the field-line term √β_i·|∇⊥Ψ| included only when Hermite moments
+    are evolved (M > 0).
 
     Args:
         state: Current KRMHD state (used to compute max velocity)
@@ -1199,9 +1205,22 @@ def compute_cfl_timestep(
         >>> new_state = gandalf_step(state, dt, eta=0.01, v_A=1.0)
 
     Physics:
-        - Alfvén waves propagate at v_A along field lines (parallel)
-        - Perpendicular flows from E×B drift: v_⊥ = ẑ × ∇φ
-        - CFL violation → exponential instability
+        - Alfvén waves propagate at v_A along field lines (parallel).
+        - In the Elsasser system, z⁺ is advected by ẑ×∇z⁻ and z⁻ by ẑ×∇z⁺,
+          so the perpendicular advection speeds are |∇⊥z∓|, NOT |∇⊥φ|.
+          Since φ = (z⁺+z⁻)/2 is their average, |∇⊥φ| ≤ max(|∇⊥z±|), with
+          equality only for purely balanced states. A φ-based bound
+          underestimates the advection by up to 2x when b⊥ ~ u⊥, and by an
+          arbitrary factor in imbalanced states: for z⁺ = -z⁻, φ ≡ 0
+          identically while the nonlinear advection (from Ψ = (z⁺-z⁻)/2)
+          remains finite.
+        - Hermite moments g are advected perpendicular by φ AND streamed
+          along perturbed field lines via the √β_i·{Ψ, ·} term — an
+          effective perpendicular advection at speed √β_i·|∇⊥Ψ|, which
+          exceeds the Elsasser bound max|∇⊥z±| when β_i > ~1.
+        - CFL violation → exponential instability. An eroding CFL margin as
+          forced runs grow in amplitude is a candidate mechanism for the
+          late-time blowups of Issue #136.
 
     Note:
         For typical KRMHD with strong guide field, v_A usually dominates
@@ -1215,26 +1234,34 @@ def compute_cfl_timestep(
     dz = grid.Lz / grid.Nz
     min_spacing = min(dx, dy, dz)
 
-    # Maximum perpendicular velocity: |v_⊥| = |∇φ|
-    # φ = (z⁺ + z⁻) / 2
-    phi = (state.z_plus + state.z_minus) / 2.0
+    def max_perp_gradient(field: Array) -> Array:
+        """Max over real space of |∇⊥f| for a Fourier-space field f."""
+        df_dx = derivative_x(field, grid.kx)
+        df_dy = derivative_y(field, grid.ky)
+        df_dx_real = rfftn_inverse(df_dx, grid.Nz, grid.Ny, grid.Nx)
+        df_dy_real = rfftn_inverse(df_dy, grid.Nz, grid.Ny, grid.Nx)
+        return jnp.sqrt(df_dx_real**2 + df_dy_real**2).max()
 
-    # Compute gradients in Fourier space, then transform to real space
-    dphi_dx = derivative_x(phi, grid.kx)
-    dphi_dy = derivative_y(phi, grid.ky)
+    # Elsasser cross-advection speeds: z± is advected by ẑ×∇z∓, so both
+    # |∇⊥z⁺| and |∇⊥z⁻| bound the perpendicular dynamics. This dominates
+    # the |∇⊥φ| estimate (φ is the average of z±, so its gradient never
+    # exceeds the larger of the two).
+    v_z_plus_max = max_perp_gradient(state.z_plus)
+    v_z_minus_max = max_perp_gradient(state.z_minus)
 
-    # Transform to real space to find maximum
-    dphi_dx_real = rfftn_inverse(dphi_dx, grid.Nz, grid.Ny, grid.Nx)
-    dphi_dy_real = rfftn_inverse(dphi_dy, grid.Nz, grid.Ny, grid.Nx)
+    v_max = jnp.maximum(v_A, jnp.maximum(v_z_plus_max, v_z_minus_max))
 
-    # Maximum velocity magnitude
-    v_perp_max = jnp.sqrt(dphi_dx_real**2 + dphi_dy_real**2).max()
-    v_max = jnp.maximum(v_A, v_perp_max)
+    if state.M > 0:
+        # Field-line streaming of Hermite moments: √β_i·{Ψ, g} acts as
+        # perpendicular advection at speed √β_i·|∇⊥Ψ| with Ψ = (z⁺-z⁻)/2.
+        Psi = (state.z_plus - state.z_minus) / 2.0
+        v_fieldline_max = jnp.sqrt(state.beta_i) * max_perp_gradient(Psi)
+        v_max = jnp.maximum(v_max, v_fieldline_max)
 
     # CFL timestep
     dt_cfl = cfl_safety * min_spacing / v_max
 
-    # Note: No Hermite streaming constraint needed for either scheme.
+    # Note: No parallel Hermite streaming constraint needed for either scheme.
     # - Lawson path: the integrating factor handles oscillatory streaming
     #   terms exactly (unitary propagator).
     # - IMEX path (Issue #137): streaming is part of the implicit operator

--- a/tests/test_timestepping.py
+++ b/tests/test_timestepping.py
@@ -19,7 +19,13 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from krmhd.spectral import SpectralGrid3D, rfftn_forward
+from krmhd.spectral import (
+    SpectralGrid3D,
+    rfftn_forward,
+    rfftn_inverse,
+    derivative_x,
+    derivative_y,
+)
 from krmhd.physics import (
     KRMHDState,
     initialize_alfven_wave,
@@ -262,6 +268,48 @@ class TestGandalfStep:
         assert jnp.isclose(f_pos, jnp.conj(f_neg), rtol=1e-5)
 
 
+def _max_perp_gradient(field_hat, grid):
+    """Max over real space of |∇⊥f| (same recipe as compute_cfl_timestep)."""
+    dfdx = rfftn_inverse(derivative_x(field_hat, grid.kx), grid.Nz, grid.Ny, grid.Nx)
+    dfdy = rfftn_inverse(derivative_y(field_hat, grid.ky), grid.Nz, grid.Ny, grid.Nx)
+    return float(jnp.sqrt(dfdx**2 + dfdy**2).max())
+
+
+def _imbalanced_state(grid, M, beta_i, amplitude):
+    """Imbalanced Elsasser state z⁺ = f, z⁻ = -f with φ = (z⁺+z⁻)/2 ≡ 0.
+
+    f is a band-limited (x,y) field with max|∇⊥f| ~ amplitude, so the
+    nonlinear cross-advection (z± advected by ẑ×∇z∓) is large even though
+    the stream function vanishes identically.
+    """
+    x = jnp.linspace(0.0, grid.Lx, grid.Nx, endpoint=False)
+    y = jnp.linspace(0.0, grid.Ly, grid.Ny, endpoint=False)
+    z = jnp.linspace(0.0, grid.Lz, grid.Nz, endpoint=False)
+    Z, Y, X = jnp.meshgrid(z, y, x, indexing="ij")
+
+    # Few low-k modes (well inside the dealiasing boundary)
+    kx0 = 2.0 * jnp.pi / grid.Lx
+    ky0 = 2.0 * jnp.pi / grid.Ly
+    f_real = amplitude * (
+        jnp.sin(kx0 * X) * jnp.cos(2.0 * ky0 * Y) + 0.3 * jnp.cos(3.0 * ky0 * Y)
+    )
+    f_hat = rfftn_forward(f_real)
+
+    return KRMHDState(
+        z_plus=f_hat,
+        z_minus=-f_hat,
+        B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
+        g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1, M + 1), dtype=jnp.complex64),
+        M=M,
+        beta_i=beta_i,
+        v_th=1.0,
+        nu=0.0,
+        Lambda=1.0,
+        time=0.0,
+        grid=grid,
+    )
+
+
 class TestCFLCalculator:
     """Test CFL condition calculator."""
 
@@ -346,6 +394,84 @@ class TestCFLCalculator:
         # dt should scale linearly with safety factor
         ratio = dt_aggressive / dt_conservative
         assert jnp.isclose(ratio, 0.5 / 0.1, rtol=0.01)
+
+    def test_cfl_detects_magnetic_advection(self):
+        """CFL must see Elsasser cross-advection even when φ ≡ 0.
+
+        In the Elsasser system z⁺ is advected by ẑ×∇z⁻ and vice versa, so the
+        relevant speeds are |∇⊥z±|, not |∇⊥φ|. The imbalanced state
+        z⁺ = f, z⁻ = -f has φ = (z⁺+z⁻)/2 ≡ 0 while the nonlinear advection
+        is finite — a φ-based estimate returns the v_A-limited dt, blind to
+        arbitrarily fast magnetic (Ψ-gradient) advection.
+        """
+        grid = SpectralGrid3D.create(Nx=32, Ny=32, Nz=16, Lx=2*jnp.pi, Ly=2*jnp.pi, Lz=2*jnp.pi)
+        v_A = 1.0
+        cfl_safety = 0.3
+
+        # Amplitude large enough that max|∇⊥f| >> v_A
+        state = _imbalanced_state(grid, M=0, beta_i=1.0, amplitude=50.0)
+
+        # φ vanishes identically for this state
+        phi = (state.z_plus + state.z_minus) / 2.0
+        assert jnp.allclose(phi, 0.0, atol=1e-4)
+
+        dt = compute_cfl_timestep(state, v_A, cfl_safety)
+
+        dx = grid.Lx / grid.Nx
+        dy = grid.Ly / grid.Ny
+        dz = grid.Lz / grid.Nz
+        min_spacing = min(dx, dy, dz)
+
+        # Expected bound from the true advecting speeds max(|∇⊥z⁺|, |∇⊥z⁻|)
+        v_advect = max(
+            _max_perp_gradient(state.z_plus, grid),
+            _max_perp_gradient(state.z_minus, grid),
+        )
+        assert v_advect > 10.0 * v_A  # sanity: advection dominates v_A
+
+        expected_dt = cfl_safety * min_spacing / v_advect
+        dt_alfven_only = cfl_safety * min_spacing / v_A
+
+        assert jnp.isclose(dt, expected_dt, rtol=1e-5)
+        assert dt < dt_alfven_only
+
+    def test_cfl_fieldline_advection_beta_scaling(self):
+        """Hermite streaming along perturbed field lines scales as √β_i |∇⊥Ψ|.
+
+        With M > 0 the g moments are streamed via √β_i {Ψ, ·}, an effective
+        perpendicular advection at speed √β_i |∇⊥Ψ| that exceeds the Elsasser
+        bound when β_i > 1. For z⁺ = f, z⁻ = -f: Ψ = f and |∇⊥z±| = |∇⊥f|,
+        so with β_i = 9 the expected v_max is 3·max|∇⊥f|. The M = 0 (pure
+        fluid) version of the same state has no field-line constraint and
+        should return a ~3x larger dt.
+        """
+        grid = SpectralGrid3D.create(Nx=32, Ny=32, Nz=16, Lx=2*jnp.pi, Ly=2*jnp.pi, Lz=2*jnp.pi)
+        v_A = 1.0
+        cfl_safety = 0.3
+        beta_i = 9.0
+
+        # Moment slots present but zero — the constraint is structural (M > 0)
+        state_kinetic = _imbalanced_state(grid, M=4, beta_i=beta_i, amplitude=50.0)
+        state_fluid = _imbalanced_state(grid, M=0, beta_i=beta_i, amplitude=50.0)
+
+        dt_kinetic = compute_cfl_timestep(state_kinetic, v_A, cfl_safety)
+        dt_fluid = compute_cfl_timestep(state_fluid, v_A, cfl_safety)
+
+        dx = grid.Lx / grid.Nx
+        dy = grid.Ly / grid.Ny
+        dz = grid.Lz / grid.Nz
+        min_spacing = min(dx, dy, dz)
+
+        # Ψ = (z⁺ - z⁻)/2 = f, so v_fieldline = √β_i max|∇⊥f| = 3 max|∇⊥f|
+        psi = (state_kinetic.z_plus - state_kinetic.z_minus) / 2.0
+        grad_psi = _max_perp_gradient(psi, grid)
+        v_max_expected = jnp.sqrt(beta_i) * grad_psi
+
+        expected_dt = cfl_safety * min_spacing / v_max_expected
+        assert jnp.isclose(dt_kinetic, expected_dt, rtol=1e-5)
+
+        # Pure fluid case: only the Elsasser bound max|∇⊥z±| = max|∇⊥f| applies
+        assert jnp.isclose(dt_fluid / dt_kinetic, 3.0, rtol=1e-4)
 
 
 class TestAlfvenWavePropagation:


### PR DESCRIPTION
## Summary

`compute_cfl_timestep` computed the maximum advection speed as `max(v_A, max|∇⊥φ|)` with φ = (z⁺ + z⁻)/2. This is under-restrictive for the KRMHD system on two counts, and the returned dt stays too large as forced runs grow in amplitude.

## Physics

**1. Elsasser cross-advection.** In the Elsasser formulation, z⁺ is advected by ẑ×∇z⁻ and z⁻ by ẑ×∇z⁺, so the perpendicular advection speeds are |∇⊥z±|, not |∇⊥φ|. Since φ is the *average* of z±, |∇⊥φ| ≤ max(|∇⊥z⁺|, |∇⊥z⁻|) always — up to 2x smaller when b⊥ ~ u⊥, and smaller by an arbitrary factor in imbalanced states.

**Counterexample:** z⁺ = -z⁻ = f gives φ ≡ 0 identically, so the old estimate returned the v_A-limited dt regardless of amplitude — while the nonlinear advection (through Ψ = (z⁺ − z⁻)/2 = f) is finite and can be arbitrarily large. `test_cfl_detects_magnetic_advection` encodes exactly this state (amplitude 50, so max|∇⊥f| ≫ v_A) and fails on the old code.

**2. Field-line streaming of Hermite moments.** For M > 0 the g moments are advected perpendicular by φ *and* streamed along perturbed field lines via the √β_i·{Ψ, ·} term — an effective perpendicular advection at speed √β_i·|∇⊥Ψ|, which exceeds the Elsasser bound max|∇⊥z±| when β_i > ~1. `test_cfl_fieldline_advection_beta_scaling` checks the √β_i scaling (β_i = 9 → v_max = 3·max|∇⊥f|) and that the M = 0 version of the same state returns a ~3x larger dt.

## New bound

```
v_max = max(v_A, max|∇⊥z⁺|, max|∇⊥z⁻|, √β_i·max|∇⊥Ψ| [only when M > 0])
```

The φ-gradient computation is dropped as redundant (dominated by the z± bounds). Signature unchanged.

## Impact on dt / wall-clock

For balanced states (z⁺ ≈ z⁻ up to phases) the new bound is at most ~2x tighter than the φ-based one, so dt shrinks by up to ~2x and wall-clock per τ_A increases correspondingly. The tightening is larger for imbalanced states and for β_i > 1 (the √β_i field-line term). For quiescent/low-amplitude states where v_A dominates, dt is unchanged.

Related to #136 and #137: as forced runs grow in amplitude, the old dt stayed too large and the CFL safety margin eroded — a candidate mechanism for the late-time grid-scale pileup and NaN blowups after 100–600 τ_A.

## Testing

- New (TDD, both fail on main): `test_cfl_detects_magnetic_advection`, `test_cfl_fieldline_advection_beta_scaling` in `tests/test_timestepping.py`, plus helpers `_max_perp_gradient` / `_imbalanced_state`.
- `uv run pytest tests/test_timestepping.py -q`: **73 passed** — all four pre-existing CFL tests (`test_cfl_zero_velocity`, `test_cfl_grid_dependence`, `test_cfl_velocity_dependence`, `test_cfl_safety_factor`) pass unmodified (zero-field state is v_A-dominated → identical dt; the others assert scalings/inequalities that hold for the tighter bound).
- `uv run pytest tests/ -q --ignore=tests/test_modal.py --ignore=tests/test_performance.py`: **615 passed, 12 failed, 1 skipped**. All 12 failures are **pre-existing** — verified identical (same tests, same errors) with this change stashed on main:
  - `tests/test_io.py` — 4 turbulence-diagnostics tests (TypeError/IndexError/assertion in save/load).
  - `tests/test_physics.py::TestKRMHDState::test_energy_parseval_validation`.
  - `tests/test_run_simulation.py` — 7 tests, all from an `UnboundLocalError: cannot access local variable 'np'` at `scripts/run_simulation.py:306`: function-local `import numpy as np` (lines 101/185, forcing-config branches) shadows the module-level import, so `np.savez` fails whenever those branches don't run. Unrelated to CFL sizing.
- No test got materially slower: within `tests/`, only `test_timestepping.py` calls `compute_cfl_timestep` directly, and no test drives an integration loop off its return value.
