### PR TITLE
Add Lambda-weighted Hermite free energy invariant

### DIFF
--- a/src/krmhd/diagnostics.py
+++ b/src/krmhd/diagnostics.py
@@ -2501,10 +2501,17 @@ def _compute_rfft_weighted_energy(
 
 def hermite_moment_energy(state: KRMHDState, account_for_rfft: bool = True) -> Array:
     """
-    Compute energy in each Hermite moment: Eₘ = ∑ₖ |gₘ,ₖ|².
+    Compute the per-moment Hermite spectrum: Eₘ = ∑ₖ |gₘ,ₖ|².
 
-    Returns the energy distribution across Hermite moments, showing how
-    energy is distributed in velocity space.
+    Returns the distribution of |gₘ|² across Hermite moments, showing how
+    fluctuation amplitude is distributed in velocity space.
+
+    IMPORTANT: This is the per-moment SPECTRUM ∑ₖ|gₘ,ₖ|², NOT the conserved
+    free energy. For Λ ≠ ∞ the parallel streaming matrix T is asymmetric in
+    its (0,1) block (T[1,0] carries the (1 - 1/Λ) kinetic correction), so the
+    unweighted total ∑ₘ Eₘ is NOT conserved by the streaming dynamics. The
+    conserved quadratic invariant weights the m=0 moment by w₀ = 1 - 1/Λ —
+    use hermite_free_energy() for free-energy budgets.
 
     Args:
         state: KRMHD state with Hermite moments g[Nz, Ny, Nx//2+1, M+1]
@@ -2560,6 +2567,81 @@ def hermite_moment_energy(state: KRMHDState, account_for_rfft: bool = True) -> A
         energy = jnp.sum(g_squared, axis=(0, 1, 2))  # Shape: [M+1]
 
     return energy
+
+
+def hermite_free_energy(state: KRMHDState, account_for_rfft: bool = True) -> float:
+    """
+    Compute the Λ-weighted Hermite free energy W = ∑ₘ wₘ ∑ₖ |gₘ,ₖ|².
+
+    This is the quadratic invariant of the Hermite hierarchy, with weights
+
+        w₀ = 1 - 1/Λ,    wₘ = 1  for m ≥ 1.
+
+    Unlike the unweighted sum of hermite_moment_energy() (which is the
+    per-moment spectrum, not an invariant), W is exactly conserved by the
+    inviscid, collisionless dynamics.
+
+    Derivation (detailed balance):
+        The linear parallel streaming term is
+
+            dgₘ/dt = -i·√βᵢ·k∥·∑ₙ T[m,n]·gₙ
+
+        with the tridiagonal coupling matrix T from
+        hermite.compute_streaming_matrix():
+
+            T[0,1] = √(1/2),  T[1,0] = (1 - 1/Λ)/√2,  T[1,2] = 1,
+            T[m,m+1] = √((m+1)/2),  T[m,m-1] = √(m/2)   (m ≥ 2).
+
+        Requiring d/dt ∑ₘ wₘ|gₘ|² = 0 for ALL g and k∥ gives the
+        detailed-balance condition wₘ·T[m,n] = wₙ·T[n,m] for every pair.
+        All m ≥ 1 pairs are already symmetric, so wₘ = wₙ there; the only
+        asymmetric pair is (0,1):
+
+            w₀·√(1/2) = w₁·(1 - 1/Λ)/√2   ⇒   w₀ = (1 - 1/Λ)·w₁
+
+        i.e. (up to an overall constant) w₀ = 1 - 1/Λ and wₘ≥₁ = 1.
+
+        The perpendicular advection terms {Φ, gₘ} conserve each moment's
+        ∑ₖ|gₘ|² individually, so W is an invariant of the full nonlinear
+        hierarchy (absent collisions/dissipation). Collisions and resistive
+        damping only remove free energy: dW/dt ≤ 0.
+
+    Special cases:
+        - Λ → ∞:  w₀ → 1, recovering the unweighted sum ∑ₘ Eₘ
+        - Λ = 1:  w₀ = 0, g₀ decouples from the invariant (T[1,0] = 0)
+        - Λ = -1: w₀ = 2 — the thesis-standard α = 1 case (the code's Λ
+          relates to the thesis kinetic parameter via α = -1/Λ, see
+          docs/HERMITE_CASCADE_INVESTIGATION.md). Free-energy budgets at
+          α = 1 must weight the m = 0 moment by 2.
+
+    Positivity:
+        For 0 < Λ < 1 the weight w₀ is negative and W is not positive
+        definite. That range lies outside the physical regime —
+        hermite.compute_streaming_eigensystem() already rejects those Λ
+        values via its complex-eigenvalue check — so for all usable Λ
+        (Λ ≥ 1 or Λ < 0) the form is positive (semi-)definite, with the
+        semi-definite boundary at Λ = 1 where g₀ carries zero weight.
+
+    Args:
+        state: KRMHD state with Hermite moments g[Nz, Ny, Nx//2+1, M+1]
+        account_for_rfft: If True, properly weight rfft modes (default: True)
+
+    Returns:
+        W: Scalar free energy w₀·E₀ + ∑ₘ₌₁ᴹ Eₘ
+
+    Note:
+        For M = 0 the sum degenerates to w₀·E₀ (defined, but the streaming
+        hierarchy itself is trivial in that fluid-only limit).
+
+    Example:
+        >>> W = hermite_free_energy(state)
+        >>> # Track free-energy budget during inviscid evolution
+        >>> # (should be constant for eta = nu = 0)
+    """
+    E_m = hermite_moment_energy(state, account_for_rfft)
+    w0 = 1.0 - 1.0 / state.Lambda
+    # E_m[1:] is empty for M=0, so this degenerates cleanly to w0 * E_0
+    return float(w0 * E_m[0] + jnp.sum(E_m[1:]))
 
 
 def phase_mixing_energy(state: KRMHDState, m: int, account_for_rfft: bool = True) -> float:

--- a/src/krmhd/hermite.py
+++ b/src/krmhd/hermite.py
@@ -521,6 +521,10 @@ def check_hermite_convergence(
 
     where E_M = |gₘ|² and E_total = Σ|gₙ|² over all moments.
 
+    Note: E_total here is the unweighted per-moment spectrum sum, used only as
+    a truncation metric — it is NOT the conserved free energy when Λ ≠ ∞
+    (see diagnostics.hermite_free_energy, which weights m=0 by w₀ = 1 - 1/Λ).
+
     The energy calculation accounts for rfft format: modes with kx > 0 are
     counted twice (complex conjugate pairs), while kx = 0 is counted once.
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1536,6 +1536,199 @@ class TestHermiteMomentEnergy:
         assert E_m[-1] < E_m[-3], "High moments should be damped"
 
 
+class TestHermiteFreeEnergy:
+    """
+    Test the Λ-weighted Hermite free energy invariant (audit finding F5).
+
+    The streaming matrix T (hermite.compute_streaming_matrix) is asymmetric in
+    the (0,1) block: T[0,1] = √(1/2) but T[1,0] = (1 - 1/Λ)/√2. The quadratic
+    invariant of the streaming dynamics dgₘ/dt = -i√βᵢ·k∥·Σₙ T[m,n]·gₙ is
+    therefore the weighted sum
+
+        W = Σₘ wₘ Σₖ |gₘ,ₖ|²,   w₀ = 1 - 1/Λ,   wₘ = 1 (m ≥ 1),
+
+    fixed by detailed balance wₘ·T[m,n] = wₙ·T[n,m] — NOT the unweighted
+    Σₘ Σₖ |gₘ,ₖ|² returned by hermite_moment_energy().
+    """
+
+    M = 8
+    LAMBDA = -1.0  # thesis α = 1 ⇒ w₀ = 2, maximally distinct from unweighted
+    BETA_I = 1.0
+
+    @staticmethod
+    def _rfft_weighted_moment_sum(field_4d, Nx: int):
+        """
+        Sum a real [Nz, Ny, Nx//2+1, M+1] array over k-space, keeping the
+        moment axis, with proper rfft mode weighting: kx=0 plane counted once,
+        kx=Nyquist plane counted once (even Nx), 0 < kx < Nyquist counted
+        twice. Mirrors the accounting inside hermite_moment_energy().
+        """
+        total = jnp.sum(field_4d[:, :, 0, :], axis=(0, 1))
+        if Nx % 2 == 0:
+            total = total + 2.0 * jnp.sum(field_4d[:, :, 1:-1, :], axis=(0, 1, 2))
+            total = total + jnp.sum(field_4d[:, :, -1, :], axis=(0, 1))
+        else:
+            total = total + 2.0 * jnp.sum(field_4d[:, :, 1:, :], axis=(0, 1, 2))
+        return total
+
+    def _make_streaming_state(self, seed: int = 0, Lambda: float = None) -> KRMHDState:
+        """
+        Random band-limited Hermite moments with zero Elsasser fields.
+
+        With z± = 0 every Poisson bracket in the g-hierarchy vanishes, so
+        krmhd_rhs() reduces to pure parallel streaming.
+
+        Each moment is the rfftn of a real-space random field (guaranteeing
+        the rfft reality structure), band-limited by the dealias mask. g₁
+        additionally receives the Hilbert transform in z of g₀'s real-space
+        field (i·sign(kz)·g₀ in Fourier space — also the rfftn of a real
+        field, and band-limited since g₀ is). This correlation makes the
+        (0,1)-asymmetry violation term Σₖ k∥·Im[g₀*·g₁] accumulate coherently
+        instead of statistically averaging toward zero over the ~400 random
+        modes, so the unweighted non-conservation assertion is deterministic
+        rather than seed-dependent.
+        """
+        if Lambda is None:
+            Lambda = self.LAMBDA
+        grid = SpectralGrid3D.create(Nx=16, Ny=16, Nz=8)
+
+        key = jax.random.PRNGKey(seed)
+        keys = jax.random.split(key, self.M + 1)
+        g_moments = []
+        for m in range(self.M + 1):
+            real_field = jax.random.normal(keys[m], (grid.Nz, grid.Ny, grid.Nx))
+            g_moments.append(
+                jnp.fft.rfftn(real_field, axes=(0, 1, 2)) * grid.dealias_mask
+            )
+
+        # Correlate g₁ with g₀ (see docstring above)
+        sign_kz = jnp.sign(grid.kz)[:, None, None]
+        g_moments[1] = g_moments[1] + 1j * sign_kz * g_moments[0]
+
+        g = jnp.stack(g_moments, axis=-1).astype(jnp.complex64)
+
+        zeros = jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64)
+        state = KRMHDState(
+            z_plus=zeros,
+            z_minus=zeros,
+            B_parallel=zeros,
+            g=g,
+            M=self.M,
+            beta_i=self.BETA_I,
+            v_th=1.0,
+            nu=0.0,
+            Lambda=Lambda,
+            time=0.0,
+            grid=grid,
+        )
+
+        # Both g₀ and g₁ must be nonzero for the (0,1) asymmetry to act
+        assert float(jnp.max(jnp.abs(state.g[..., 0]))) > 0.0
+        assert float(jnp.max(jnp.abs(state.g[..., 1]))) > 0.0
+
+        return state
+
+    def test_hermite_free_energy_conserved_under_streaming(self):
+        """Streaming conserves Σₘwₘ|gₘ|² (w₀ = 1-1/Λ) but NOT Σₘ|gₘ|²."""
+        from krmhd.diagnostics import hermite_free_energy, hermite_moment_energy
+        from krmhd.timestepping import krmhd_rhs
+
+        state = self._make_streaming_state(seed=0)
+        grid = state.grid
+
+        # With z± = 0 only streaming remains:
+        # dgₘ/dt = -i√βᵢ·kz·Σₙ T[m,n]·gₙ (η irrelevant for g; ν not in RHS)
+        deriv = krmhd_rhs(state, eta=0.0, v_A=1.0)
+
+        # Per-moment dEₘ/dt = Σₖ 2·Re[gₘ*·(dg/dt)ₘ] with rfft weighting
+        dE_m = self._rfft_weighted_moment_sum(
+            2.0 * jnp.real(jnp.conj(state.g) * deriv.g), grid.Nx
+        )
+        E_m = hermite_moment_energy(state)
+
+        # Detailed-balance weights: w₀ = 1 - 1/Λ = 2 for Λ = -1, wₘ≥₁ = 1
+        w = jnp.ones(self.M + 1).at[0].set(1.0 - 1.0 / self.LAMBDA)
+
+        # The new diagnostic must implement exactly this weighted sum
+        W = hermite_free_energy(state)
+        W_manual = float(jnp.sum(w * E_m))
+        assert W > 0.0
+        assert np.isclose(W, W_manual, rtol=1e-5), (
+            f"hermite_free_energy() = {W} != manual weighted sum {W_manual}"
+        )
+
+        kz_max = float(jnp.max(jnp.abs(grid.kz)))
+        scale = float(np.sqrt(self.BETA_I)) * kz_max
+
+        # Weighted free energy: conserved to float32 roundoff
+        W_dot = float(jnp.sum(w * dE_m))
+        weighted_residual = abs(W_dot) / (scale * W)
+        assert weighted_residual < 1e-4, (
+            f"Weighted free energy not conserved under streaming: "
+            f"|dW/dt|/(√βᵢ·kz_max·W) = {weighted_residual:.3e} ≥ 1e-4"
+        )
+
+        # Unweighted sum: NOT conserved (the mislabeled 'energy' this fixes)
+        E_unweighted = float(jnp.sum(E_m))
+        E_dot_unweighted = float(jnp.sum(dE_m))
+        unweighted_residual = abs(E_dot_unweighted) / (scale * E_unweighted)
+        assert unweighted_residual > 1e-2, (
+            f"Expected unweighted Σ|gₘ|² to visibly violate conservation, "
+            f"got |dE/dt|/(√βᵢ·kz_max·E) = {unweighted_residual:.3e} ≤ 1e-2"
+        )
+
+    def test_free_energy_weight_g0_only(self):
+        """For Λ = -1 (thesis α = 1), a g₀-only state has W = 2·E₀."""
+        from krmhd.diagnostics import hermite_free_energy, hermite_moment_energy
+
+        grid = SpectralGrid3D.create(Nx=16, Ny=16, Nz=8)
+        key = jax.random.PRNGKey(3)
+        real_field = jax.random.normal(key, (grid.Nz, grid.Ny, grid.Nx))
+        g0 = jnp.fft.rfftn(real_field, axes=(0, 1, 2)) * grid.dealias_mask
+
+        g = jnp.zeros(
+            (grid.Nz, grid.Ny, grid.Nx // 2 + 1, self.M + 1), dtype=jnp.complex64
+        )
+        g = g.at[..., 0].set(g0)
+
+        zeros = jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64)
+        state = KRMHDState(
+            z_plus=zeros,
+            z_minus=zeros,
+            B_parallel=zeros,
+            g=g,
+            M=self.M,
+            beta_i=self.BETA_I,
+            v_th=1.0,
+            nu=0.0,
+            Lambda=-1.0,
+            time=0.0,
+            grid=grid,
+        )
+
+        W = hermite_free_energy(state)
+        E_m = hermite_moment_energy(state)
+
+        assert float(E_m[0]) > 0.0
+        assert np.isclose(W, 2.0 * float(E_m[0]), rtol=1e-5), (
+            f"Λ = -1 g₀-only state: W = {W} != 2·E₀ = {2.0 * float(E_m[0])}"
+        )
+
+    def test_free_energy_weight_large_lambda(self):
+        """Λ → ∞ (w₀ → 1) recovers the unweighted sum Σₘ Eₘ."""
+        from krmhd.diagnostics import hermite_free_energy, hermite_moment_energy
+
+        state = self._make_streaming_state(seed=1, Lambda=1e12)
+
+        W = hermite_free_energy(state)
+        E_unweighted = float(jnp.sum(hermite_moment_energy(state)))
+
+        assert E_unweighted > 0.0
+        assert np.isclose(W, E_unweighted, rtol=1e-5), (
+            f"Λ = 1e12: weighted W = {W} != unweighted Σ Eₘ = {E_unweighted}"
+        )
+
+
 class TestPhaseMixingEnergy:
     """Test phase mixing/unmixing energy decomposition."""
 


### PR DESCRIPTION
## Summary

Adds `hermite_free_energy()` — the Λ-weighted quadratic invariant of the Hermite kinetic sector — and corrects the docstrings of `hermite_moment_energy()` / `check_hermite_convergence()`, which presented the unweighted sum Σₘ|gₘ|² as "energy" even though it is not conserved by the streaming dynamics (audit finding F5). No behavior change to any existing function.

## Derivation

The kinetic sector evolves under linear parallel streaming

```
dgₘ/dt = -i·√βᵢ·k∥·Σₙ T[m,n]·gₙ
```

with the tridiagonal coupling matrix T from `compute_streaming_matrix` (`src/krmhd/hermite.py`):

```
T[0,1] = √(1/2),   T[1,0] = (1 - 1/Λ)/√2,   T[1,2] = 1,
T[m,m+1] = √((m+1)/2),   T[m,m-1] = √(m/2)    (m ≥ 2)
```

Because the m=0↔1 coupling is asymmetric (the (1 - 1/Λ) kinetic correction in the g₁ equation), the quadratic invariant conserved by streaming is **not** the unweighted Σₘ|gₘ|². Requiring d/dt Σₘ wₘ|gₘ|² = 0 for all g and k∥ gives the detailed-balance condition wₘ·T[m,n] = wₙ·T[n,m]; the only nontrivial pair is (0,1):

```
w₀·√(1/2) = w₁·(1 - 1/Λ)/√2   ⇒   w₀ = 1 - 1/Λ,   wₘ = 1 for m ≥ 1
```

(up to an overall constant). The perpendicular advection terms {Φ, gₘ} conserve each moment's Σₖ|gₘ|² individually, so the weighted form is the invariant of the full nonlinear hierarchy absent collisions/dissipation (which make dW/dt ≤ 0).

Special cases:
- Λ → ∞: w₀ → 1 (unweighted sum recovered)
- Λ = 1: w₀ = 0 (g₀ decouples from the invariant)
- Λ = -1 (thesis-standard α = 1, since α = -1/Λ per `docs/HERMITE_CASCADE_INVESTIGATION.md`): **w₀ = 2**

## Why the unweighted sum is not conserved (measured)

`tests/test_diagnostics.py::TestHermiteFreeEnergy::test_hermite_free_energy_conserved_under_streaming` builds a random band-limited g (rfftn of a real-space random field per moment, dealias-masked; g₁ additionally carries the z-Hilbert transform of g₀'s field so the (0,1)-asymmetry term Σₖ k∥·Im[g₀*g₁] accumulates coherently instead of statistically cancelling over ~400 modes) with z± = 0, Λ = -1, βᵢ = 1, ν = 0, M = 8 on a 16×16×8 grid, and computes dg/dt through the public `krmhd_rhs` (with z± = 0 the Poisson brackets vanish and only streaming remains). Normalized drift |Ẇ| / (√βᵢ·max|k∥|·W):

| Quantity | measured drift | test bound |
|---|---|---|
| Weighted W (w₀ = 2) | ~4.0e-08 | < 1e-4 (float32 headroom) |
| Unweighted Σₘ Eₘ | **~3.9e-02** | > 1e-2 (non-conservation demo) |

The unweighted sum drifts at the percent level (per parallel-streaming time) from linear physics alone — a diagnostic mislabeling, not a solver error (the solver is untouched).

## Impact

- Free-energy budgets and the m=0 point of Hermite "energy" spectra at thesis α = 1 (Λ = -1) were off by 2× (w₀ = 2 vs the implicit 1).
- m ≥ 1 spectrum values/slopes are unaffected (wₘ = 1 there).
- `hermite_moment_energy` remains correct and unchanged as a per-moment spectrum; its docstring (and `check_hermite_convergence`'s) now says so explicitly and points to `hermite_free_energy` for budgets.

## Changes

- `src/krmhd/diagnostics.py`: new `hermite_free_energy(state, account_for_rfft=True)` right after `hermite_moment_energy`, implemented as w₀·E₀ + Σₘ₌₁ Eₘ on top of `hermite_moment_energy` (degenerates cleanly to w₀·E₀ for M = 0); docstring correction on `hermite_moment_energy`.
- `src/krmhd/hermite.py`: docstring clarification in `check_hermite_convergence`.
- `tests/test_diagnostics.py`: new `TestHermiteFreeEnergy` class — streaming conservation test (written first, TDD; weighted form conserved, unweighted demonstrably not) plus weight unit tests (Λ = -1 g₀-only state gives W = 2·E₀; Λ = 1e12 gives weighted ≈ unweighted).
- Exports: `hermite_moment_energy` is not exported from `src/krmhd/__init__.py` (it is consumed via `krmhd.diagnostics`, which has no `__all__`), so `hermite_free_energy` gets identical visibility with no `__init__.py` change.

## Test results

- `uv run pytest tests/test_diagnostics.py tests/test_hermite.py -q`: **135 passed** (5 pre-existing warnings).
- `uv run pytest tests/ -q --ignore=tests/test_modal.py --ignore=tests/test_performance.py`: **616 passed, 12 failed, 1 skipped**.

### Pre-existing failures (not fixed here)

The 12 failures reproduce identically on clean `main` (4558b96, verified in a detached worktree) and are unrelated to this change (no file touched here is involved):

- `tests/test_io.py`: `test_turbulence_diagnostics_roundtrip`, `test_turbulence_diagnostics_metadata_preservation`, `test_turbulence_diagnostics_empty_list`, `test_turbulence_diagnostics_compression`
- `tests/test_physics.py`: `TestKRMHDState::test_energy_parseval_validation`
- `tests/test_run_simulation.py`: `test_run_simulation_minimal`, `test_run_simulation_no_overwrite_error`, `test_run_simulation_with_overwrite`, `test_creates_nested_directories`, `test_empty_directory_reuse_allowed`, `test_moderate_cfl_violation_warns`, `test_checkpoint_interval_creates_checkpoints` (all via an `UnboundLocalError` in `scripts/run_simulation.py:306`)
