### PR TITLE
Add parallel (kz) hyper-dissipation matching original GANDALF dampz

### DIFF
--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -211,7 +211,9 @@ def run_simulation(
             v_A=config.physics.v_A,
             nu=config.physics.nu,
             hyper_r=config.physics.hyper_r,
-            hyper_n=config.physics.hyper_n
+            hyper_n=config.physics.hyper_n,
+            eta_z=config.physics.eta_z,
+            hyper_rz=config.physics.hyper_rz
         )
         t += dt
 

--- a/src/krmhd/config.py
+++ b/src/krmhd/config.py
@@ -79,6 +79,15 @@ class PhysicsConfig(BaseModel):
     hyper_r: int = Field(1, description="Hyper-resistivity order (1, 2, 4, or 8)")
     hyper_n: int = Field(1, description="Hyper-collision order (1, 2, 3, 4, or 6)")
 
+    # Parallel (kz) hyper-dissipation (original GANDALF dampz, damping_kernel.cu:4-33)
+    # One coefficient shared by z± and all Hermite moments (see gandalf_step docstring)
+    eta_z: float = Field(
+        0.0, ge=0, description="Parallel (kz) hyper-resistivity coefficient (0 = disabled)"
+    )
+    hyper_rz: int = Field(
+        1, description="Parallel hyper-resistivity order (1, 2, 4, or 8)"
+    )
+
     @field_validator('hyper_r')
     @classmethod
     def check_hyper_r(cls, v: int) -> int:
@@ -87,6 +96,17 @@ class PhysicsConfig(BaseModel):
             raise ValueError(
                 f"hyper_r must be 1, 2, 4, or 8 (got {v}). "
                 "Use r=1 for standard dissipation, r=2 for typical turbulence studies."
+            )
+        return v
+
+    @field_validator('hyper_rz')
+    @classmethod
+    def check_hyper_rz(cls, v: int) -> int:
+        """Validate hyper_rz matches timestepping.py constraints."""
+        if v not in {1, 2, 4, 8}:
+            raise ValueError(
+                f"hyper_rz must be 1, 2, 4, or 8 (got {v}). "
+                "Use rz=1 for standard parallel dissipation, rz=2 for a sharper kz cutoff."
             )
         return v
 
@@ -528,6 +548,11 @@ class SimulationConfig(BaseModel):
         if self.physics.hyper_r > 1 or self.physics.hyper_n > 1:
             lines.extend([
                 f"  Hyper-dissipation: r = {self.physics.hyper_r}, n = {self.physics.hyper_n}",
+            ])
+
+        if self.physics.eta_z > 0:
+            lines.extend([
+                f"  Parallel (kz) dissipation: η_z = {self.physics.eta_z}, rz = {self.physics.hyper_rz}",
             ])
 
         lines.extend([

--- a/src/krmhd/timestepping.py
+++ b/src/krmhd/timestepping.py
@@ -312,7 +312,9 @@ def krmhd_rhs(
 # =============================================================================
 
 
-@partial(jax.jit, static_argnames=["Nz", "Ny", "Nx", "M", "hyper_r", "hyper_n"])
+@partial(
+    jax.jit, static_argnames=["Nz", "Ny", "Nx", "M", "hyper_r", "hyper_n", "hyper_rz"]
+)
 def _gandalf_step_lawson_rk4_jit(
     fields: KRMHDFields,
     dt: float,
@@ -331,6 +333,8 @@ def _gandalf_step_lawson_rk4_jit(
     Nx: int,
     hyper_r: int = 1,
     hyper_n: int = 1,
+    eta_z: float = 0.0,
+    hyper_rz: int = 1,
     streaming_eigenvalues: Array = None,
     streaming_P_T: Array = None,
     streaming_P_inv_T: Array = None,
@@ -374,6 +378,15 @@ def _gandalf_step_lawson_rk4_jit(
             - n=3: Strong hyper-collision -νm³ (matches original GANDALF alpha_m=3)
             - n=4: Very strong hyper-collision -νm⁴ (expert use, requires small nu)
             - n=6: Thesis Figure 3.3 benchmark value for strong high-m damping
+        eta_z: Parallel (kz) hyper-resistivity coefficient (default: 0.0, disabled).
+            Post-step multiplicative damping exp(-η_z·(kz²/kz²_max)^rz·dt) applied
+            to ξ± AND all Hermite moments, with kz_max at the 2/3 dealias boundary
+            (idz_max = (Nz-1)//3). Matches original GANDALF dampz
+            (damping_kernel.cu:4-33, applied every step in timestep.cu:94-108).
+        hyper_rz: Parallel hyper-resistivity order (default: 1, static)
+            - rz=1: Standard parallel dissipation ∝ kz²
+            - rz=2: Moderate parallel hyper-dissipation ∝ kz⁴
+            - rz=4, 8: Sharper parallel cutoffs (expert use)
         streaming_eigenvalues: Eigenvalues of streaming matrix T (from compute_streaming_eigensystem).
             Must be provided — None default is only for Python syntax (keyword after default args).
         streaming_P_T: Transposed right eigenvector matrix P.T (from compute_streaming_eigensystem).
@@ -604,6 +617,27 @@ def _gandalf_step_lawson_rk4_jit(
         )  # Shape: [M+1]
         g_new = g_new * collision_factors[jnp.newaxis, jnp.newaxis, jnp.newaxis, :]  # (2) Collisional damping
 
+    # Parallel (kz) hyper-dissipation, the parallel analogue of the normalized
+    # perpendicular hyper-resistivity above. Matches original GANDALF dampz
+    # (damping_kernel.cu:4-33), applied every step to the Elsasser fields and
+    # every Hermite moment (timestep.cu:94-108):
+    #   ξ±, g_m → exp(-η_z·(kz²/kz²_max)^rz·dt) with kz_max at the 2/3 dealias
+    #   boundary, idz_max = (Nz-1)//3 (same pattern as idx_max/idy_max above).
+    # Multiplicative factors commute, so ordering within this section is exact.
+    idz_max = (Nz - 1) // 3  # Python int: Nz is static, resolved at trace time
+    if idz_max >= 1:
+        # Static branch: skipped entirely for tiny Nz (e.g. Nz=2 used by 2D-style
+        # tests) where kz[idz_max]=kz[0]=0 would give a divide-by-zero inf, and
+        # 0·inf = NaN inside exp even for eta_z=0. The original GANDALF likewise
+        # guarded dampz with `if (Nz > 1)`.
+        # fftfreq ordering: idz_max < Nz/2 lands in the positive-kz range.
+        kz_max_squared = kz[idz_max] ** 2
+        kz_2rz_normalized = (kz_3d**2 / kz_max_squared) ** hyper_rz
+        z_dissipation_factor = jnp.exp(-eta_z * kz_2rz_normalized * dt)
+        z_plus_new = z_plus_new * z_dissipation_factor
+        z_minus_new = z_minus_new * z_dissipation_factor
+        g_new = g_new * z_dissipation_factor[:, :, :, jnp.newaxis]
+
     # Project Hermite moments back to the resolved 3D spectral band. The Hermite
     # Poisson-bracket RHS is already dealiased in physics.py, so this is a
     # defensive guarantee against externally injected or checkpointed out-of-band
@@ -649,7 +683,7 @@ _NU_IN_IMPLICIT_OPERATOR: float = 0.0
 # baked into L_per_kz (via _damping_diag) before this JIT kernel is called.
 # Adding it here would force a needless recompile whenever hyper_n changed,
 # even though the traced graph has no direct dependence on it.
-@partial(jax.jit, static_argnames=["Nz", "Ny", "Nx", "M", "hyper_r"])
+@partial(jax.jit, static_argnames=["Nz", "Ny", "Nx", "M", "hyper_r", "hyper_rz"])
 def _gandalf_step_imex222_jit(
     fields: KRMHDFields,
     dt: float,
@@ -670,6 +704,8 @@ def _gandalf_step_imex222_jit(
     L_per_kz: Array,
     lu: Array,
     piv: Array,
+    eta_z: float = 0.0,
+    hyper_rz: int = 1,
 ) -> KRMHDFields:
     """
     JIT-compiled IMEX-RK222 (Ascher-Ruuth-Spiteri 1997, ARS(2,2,2)) stepper.
@@ -710,6 +746,14 @@ def _gandalf_step_imex222_jit(
     L and its factorization (lu, piv) are precomputed per step outside
     this JIT kernel (see gandalf_step). Hyper-collisional damping is folded
     into L; the exponential collision factor is therefore NOT applied here.
+
+    Parallel (kz) hyper-dissipation (eta_z, hyper_rz): applied post-step as
+    exp(-eta_z*(kz^2/kz_max^2)^hyper_rz*dt) to z+/-, and to all Hermite
+    moments, with kz_max at the 2/3 dealias boundary (idz_max = (Nz-1)//3).
+    Matches original GANDALF dampz (damping_kernel.cu:4-33, applied every
+    step in timestep.cu:94-108) and is applied at the same point as in the
+    Lawson kernel so the two schemes stay equivalent. Default eta_z=0.0 is
+    an exact no-op.
 
     Known limitation — resistivity splitting:
         Resistive damping on g is applied as an exponential post-step factor
@@ -858,6 +902,28 @@ def _gandalf_step_imex222_jit(
     # kernel multiplies uniformly across all Hermite moments of g.
     g_new = g_new * perp_dissipation_factor[:, :, :, jnp.newaxis]
 
+    # Parallel (kz) hyper-dissipation, the parallel analogue of the normalized
+    # perpendicular hyper-resistivity above. Matches original GANDALF dampz
+    # (damping_kernel.cu:4-33), applied every step to the Elsasser fields and
+    # every Hermite moment (timestep.cu:94-108):
+    #   z±, g_m → exp(-η_z·(kz²/kz²_max)^rz·dt) with kz_max at the 2/3 dealias
+    #   boundary, idz_max = (Nz-1)//3 (same pattern as idx_max/idy_max above).
+    # Same placement as in _gandalf_step_lawson_rk4_jit (post-step dissipation,
+    # before the defensive dealias) so the two schemes stay equivalent.
+    idz_max = (Nz - 1) // 3  # Python int: Nz is static, resolved at trace time
+    if idz_max >= 1:
+        # Static branch: skipped entirely for tiny Nz (e.g. Nz=2 used by 2D-style
+        # tests) where kz[idz_max]=kz[0]=0 would give a divide-by-zero inf, and
+        # 0·inf = NaN inside exp even for eta_z=0. The original GANDALF likewise
+        # guarded dampz with `if (Nz > 1)`.
+        # fftfreq ordering: idz_max < Nz/2 lands in the positive-kz range.
+        kz_max_squared = kz[idz_max] ** 2
+        kz_2rz_normalized = (kz_3d**2 / kz_max_squared) ** hyper_rz
+        z_dissipation_factor = jnp.exp(-eta_z * kz_2rz_normalized * dt)
+        z_plus_new = z_plus_new * z_dissipation_factor
+        z_minus_new = z_minus_new * z_dissipation_factor
+        g_new = g_new * z_dissipation_factor[:, :, :, jnp.newaxis]
+
     # Defensive dealias of Hermite moments. z+/- are NOT dealiased here by
     # design: their dealiasing is already done inside _krmhd_rhs_jit via the
     # Poisson-bracket evaluation (spectral.poisson_bracket_3d applies the
@@ -888,6 +954,8 @@ def gandalf_step(
     hyper_r: int = 1,
     hyper_n: int = 1,
     scheme: Scheme = "imex_rk222",
+    eta_z: float = 0.0,
+    hyper_rz: int = 1,
 ) -> KRMHDState:
     """
     Advance KRMHD state using the mixed GANDALF integrating-factor method.
@@ -948,6 +1016,30 @@ def gandalf_step(
             1e-6 per step (~5e-4 over 200 steps; see
             test_imex222_nontrivial_vA_matches_lawson). For bit-level
             reproducibility across reruns, pin `scheme=` explicitly.
+        eta_z: Parallel (kz) hyper-resistivity coefficient (default: 0.0, disabled).
+            Post-step multiplicative damping exp(-η_z·(kz²/kz²_max)^rz·dt)
+            applied to z⁺, z⁻ AND all Hermite moments g, with kz_max at the
+            2/3 dealias boundary (idz_max = (Nz-1)//3). This is the exact
+            parallel analogue of the normalized perpendicular hyper-resistivity
+            eta, and matches original GANDALF dampz (damping_kernel.cu:4-33),
+            which was applied every step to the Elsasser fields and every
+            Hermite moment (timestep.cu:94-108). It regulates the parallel
+            (kz) spectrum, which otherwise has no dissipation channel
+            (relevant to Issues #136 and #137).
+
+            DELIBERATE DEVIATION from original GANDALF: the original used a
+            separate coefficient nu_kz_g (with order alpha_kz_g) for the
+            Hermite moments; here a single coefficient eta_z (and single
+            order hyper_rz) is shared by z± and g, exactly as the existing
+            perpendicular eta is shared across all three fields.
+
+            Default 0.0 gives exactly zero behavior change (the damping
+            factor is identically 1).
+        hyper_rz: Parallel hyper-resistivity order (default: 1)
+            - rz=1: Standard parallel dissipation ∝ kz²
+            - rz=2: Moderate parallel hyper-dissipation ∝ kz⁴
+            - rz=4: Strong parallel hyper-dissipation ∝ kz⁸ (expert use)
+            - rz=8: Maximum parallel hyper-dissipation ∝ kz¹⁶ (expert use)
 
     Returns:
         New KRMHDState at time t + dt
@@ -955,10 +1047,16 @@ def gandalf_step(
     Raises:
         ValueError: If hyper_r not in [1, 2, 4, 8]
         ValueError: If hyper_n not in [1, 2, 3, 4, 6]
+        ValueError: If hyper_rz not in [1, 2, 4, 8]
         ValueError: If scheme not in {"lawson_rk4", "imex_rk222"}
         ValueError: If hyper-collision overflow risk detected (nu·dt >= 50, normalized;
             Lawson path only — the IMEX solve is unconditionally stable)
         ValueError: If hyper-resistivity overflow risk detected (eta·dt >= 50, normalized)
+        ValueError: If parallel hyper-resistivity overflow risk detected
+            (eta_z·dt >= 50, normalized)
+        ValueError: If eta_z > 0 but the grid is too small in z for normalized
+            kz damping ((Nz-1)//3 < 1, i.e. no nonzero kz mode inside the 2/3
+            dealias boundary; the original GANDALF guarded dampz with `if (Nz > 1)`)
 
     Example:
         >>> # Standard dissipation (backward compatible)
@@ -1020,10 +1118,17 @@ def gandalf_step(
         - Maximum damping rate at k⊥=k⊥_max is simply: η·dt (independent of grid!)
         - Must satisfy: η·dt < 50 to avoid underflow
 
+        Parallel hyper-resistivity overflow risk (eta_z > 0):
+        - NORMALIZED formulation: exp(-η_z·(kz²/kz²_max)^rz·dt)
+        - Maximum damping rate at kz=kz_max is simply: η_z·dt (independent of Nz!)
+        - Must satisfy: η_z·dt < 50 to avoid underflow (same thresholds as eta)
+
     Reference:
         - Thesis Chapter 2, §2.4 - GANDALF Algorithm
         - Eqs. 2.13-2.25 - Integrating factor implementation
         - Thesis §2.5.2 - Hyper-dissipation for inertial range studies
+        - Original GANDALF: damping_kernel.cu:4-33 (dampz kernel) and
+          timestep.cu:94-108 (per-step dampz on z± and every Hermite moment)
     """
     # Use provided nu or fall back to state.nu
     nu_effective = nu if nu is not None else state.nu
@@ -1034,6 +1139,9 @@ def gandalf_step(
 
     if hyper_n not in (1, 2, 3, 4, 6):
         raise ValueError(f"hyper_n must be 1, 2, 3, 4, or 6 (got {hyper_n})")
+
+    if hyper_rz not in (1, 2, 4, 8):
+        raise ValueError(f"hyper_rz must be 1, 2, 4, or 8 (got {hyper_rz})")
 
     if scheme not in ("lawson_rk4", "imex_rk222"):
         raise ValueError(
@@ -1099,6 +1207,41 @@ def gandalf_step(
             RuntimeWarning
         )
 
+    # Safety check for parallel (kz) hyper-resistivity overflow, mirroring eta.
+    # NORMALIZED formulation exp(-η_z·(kz²/kz²_max)^rz·dt): maximum rate at
+    # kz=kz_max is simply η_z·dt (matches original GANDALF damping_kernel.cu:4-33)
+    max_kz_resistivity_rate = eta_z * dt
+
+    if max_kz_resistivity_rate >= MAX_DAMPING_RATE_THRESHOLD:
+        safe_eta_z = MAX_DAMPING_RATE_THRESHOLD / dt
+        raise ValueError(
+            f"Parallel hyper-resistivity overflow risk detected!\n"
+            f"  Parameter: eta_z·dt = {eta_z}·{dt} = {max_kz_resistivity_rate:.2e}\n"
+            f"  Threshold: Must be < {MAX_DAMPING_RATE_THRESHOLD} to avoid exp() underflow\n"
+            f"  Solution: Reduce eta_z to < {safe_eta_z:.2e} or reduce dt\n"
+            f"  Note: With normalized dissipation, constraint is eta_z·dt < {MAX_DAMPING_RATE_THRESHOLD} (independent of resolution or rz!)"
+        )
+
+    # Warning for moderate risk (20-50)
+    if max_kz_resistivity_rate >= DAMPING_RATE_WARNING_THRESHOLD:
+        warnings.warn(
+            f"Parallel hyper-resistivity damping rate is high: eta_z·dt = {max_kz_resistivity_rate:.2e}. "
+            f"Consider reducing eta_z or dt to improve numerical stability.",
+            RuntimeWarning
+        )
+
+    # Normalized kz damping needs at least one nonzero kz mode inside the 2/3
+    # dealias boundary: idz_max = (Nz-1)//3 >= 1. For tiny Nz (e.g. Nz=2,
+    # the 2D-style grids) kz[idz_max] = 0 and the normalization is undefined.
+    # The original GANDALF guarded dampz with `if (Nz > 1)`; the JIT kernels
+    # skip the kz damping block entirely (static branch) in that case.
+    if eta_z > 0 and (state.grid.Nz - 1) // 3 < 1:
+        raise ValueError(
+            f"eta_z > 0 requires a grid with (Nz-1)//3 >= 1 (got Nz={state.grid.Nz}). "
+            f"Normalized parallel dissipation exp(-eta_z·(kz²/kz²_max)^rz·dt) needs "
+            f"a nonzero kz_max at the 2/3 dealias boundary; use Nz >= 4 or set eta_z=0."
+        )
+
     grid = state.grid
     fields = _fields_from_state(state)
 
@@ -1126,6 +1269,8 @@ def gandalf_step(
             grid.Nx,
             hyper_r,
             hyper_n,
+            eta_z=eta_z,
+            hyper_rz=hyper_rz,
             streaming_eigenvalues=eigenvalues,
             streaming_P_T=P.T,
             streaming_P_inv_T=P_inv.T,
@@ -1164,6 +1309,8 @@ def gandalf_step(
             L_per_kz,
             lu,
             piv,
+            eta_z=eta_z,
+            hyper_rz=hyper_rz,
         )
 
     # Convert back to KRMHDState (Pydantic validation at boundary)

--- a/tests/test_kz_damping.py
+++ b/tests/test_kz_damping.py
@@ -59,9 +59,11 @@ class TestKzDampingNoOp:
         s_default = gandalf_step(state, dt, eta=0.01, v_A=1.0)
         s_explicit = gandalf_step(state, dt, eta=0.01, v_A=1.0, eta_z=0.0, hyper_rz=1)
 
+        # Only the dynamically evolved fields are compared; B_parallel is
+        # frozen pass-through state and is being removed entirely in
+        # refactor/remove-b-parallel (PR #149).
         assert jnp.allclose(s_default.z_plus, s_explicit.z_plus, rtol=0.0, atol=0.0)
         assert jnp.allclose(s_default.z_minus, s_explicit.z_minus, rtol=0.0, atol=0.0)
-        assert jnp.allclose(s_default.B_parallel, s_explicit.B_parallel, rtol=0.0, atol=0.0)
         assert jnp.allclose(s_default.g, s_explicit.g, rtol=0.0, atol=0.0)
 
     def test_nz2_grid_runs_without_nan_with_defaults(self):
@@ -157,7 +159,7 @@ class TestKzDampingHermiteMoments:
         state = KRMHDState(
             z_plus=zeros,
             z_minus=zeros,
-            B_parallel=zeros,
+            B_parallel=zeros,  # required pre-#149; ignored extra kwarg after it merges
             g=g,
             M=M,
             beta_i=1.0,

--- a/tests/test_kz_damping.py
+++ b/tests/test_kz_damping.py
@@ -1,0 +1,250 @@
+"""
+Tests for parallel (kz) hyper-dissipation in gandalf_step (audit finding F4).
+
+The original CUDA GANDALF applies parallel hyper-dissipation every step to the
+Elsasser fields and to every Hermite moment (timestep.cu:94-108, `dampz`), with
+kernel (damping_kernel.cu:4-33):
+
+    znew *= exp(-nu_kz * dt * |kz / kz(idmax)|^(2*alpha_z)),  idmax = (Nz-1)/3
+
+i.e. normalized parallel hyper-dissipation exp(-eta_z * (kz^2/kz_max^2)^rz * dt)
+with kz_max at the 2/3 dealias boundary — the exact parallel analogue of the
+perpendicular normalized hyper-resistivity already in timestepping.py.
+
+This suite validates:
+- Default no-op guarantee: eta_z=0.0, hyper_rz=1 changes nothing
+- Nz=2 (2D-style) grids run without NaN under defaults (static idz_max guard)
+- Single-Alfven-mode amplitude decay matches exp(-eta_z*(kz^2/kz_max^2)^rz * t)
+  for hyper_rz in {1, 2} and both integrator schemes
+- Hermite moments g decay at the same kz-dependent rate, uniformly across moments
+- Input validation: hyper_rz allow-list, eta_z*dt overflow, Nz too small in z
+"""
+
+import pytest
+import jax.numpy as jnp
+
+from krmhd.spectral import SpectralGrid3D
+from krmhd.physics import (
+    KRMHDState,
+    initialize_alfven_wave,
+    initialize_hermite_moments,
+    initialize_orszag_tang,
+    initialize_random_spectrum,
+)
+from krmhd.timestepping import gandalf_step
+
+
+def _kz_max_squared(grid: SpectralGrid3D) -> float:
+    """kz_max^2 at the 2/3 dealias boundary, computed the same way the kernel does.
+
+    idz_max = (Nz - 1) // 3 indexes into grid.kz which uses fftfreq ordering
+    [0, 1, ..., Nz/2-1, -Nz/2, ..., -1]; idz_max < Nz/2 lands in the
+    positive-kz range (matches original GANDALF damping_kernel.cu idmax).
+    """
+    idz_max = (grid.Nz - 1) // 3
+    return float(grid.kz[idz_max]) ** 2
+
+
+class TestKzDampingNoOp:
+    """Defaults must give exactly zero behavior change."""
+
+    def test_defaults_identical_to_explicit_zero(self):
+        """gandalf_step with and without explicit eta_z=0.0, hyper_rz=1 must agree."""
+        grid = SpectralGrid3D.create(Nx=16, Ny=16, Nz=16)
+        state = initialize_random_spectrum(
+            grid, M=4, amplitude=0.1, g_perturbation_amplitude=1e-3
+        )
+        dt = 0.01
+
+        s_default = gandalf_step(state, dt, eta=0.01, v_A=1.0)
+        s_explicit = gandalf_step(state, dt, eta=0.01, v_A=1.0, eta_z=0.0, hyper_rz=1)
+
+        assert jnp.allclose(s_default.z_plus, s_explicit.z_plus, rtol=0.0, atol=0.0)
+        assert jnp.allclose(s_default.z_minus, s_explicit.z_minus, rtol=0.0, atol=0.0)
+        assert jnp.allclose(s_default.B_parallel, s_explicit.B_parallel, rtol=0.0, atol=0.0)
+        assert jnp.allclose(s_default.g, s_explicit.g, rtol=0.0, atol=0.0)
+
+    def test_nz2_grid_runs_without_nan_with_defaults(self):
+        """2D-style Nz=2 grid must not NaN: static idz_max guard skips kz damping.
+
+        Without the static `if idz_max >= 1` guard, kz[0]=0 would give a
+        divide-by-zero inf, and 0 * inf = NaN inside exp even for eta_z=0.
+        """
+        grid = SpectralGrid3D.create(Nx=32, Ny=32, Nz=2, Lx=1.0, Ly=1.0, Lz=1.0)
+        state = initialize_orszag_tang(grid, M=0)
+
+        current = state
+        for _ in range(3):
+            current = gandalf_step(current, dt=0.001, eta=0.0, v_A=1.0, nu=0.0)
+
+        assert jnp.all(jnp.isfinite(current.z_plus))
+        assert jnp.all(jnp.isfinite(current.z_minus))
+        assert jnp.all(jnp.isfinite(current.g))
+
+
+class TestKzDampingDecayRate:
+    """Amplitude decay must match exp(-eta_z*(kz^2/kz_max^2)^rz * t) within ~1%."""
+
+    @pytest.mark.parametrize("scheme", ["imex_rk222", "lawson_rk4"])
+    @pytest.mark.parametrize("hyper_rz", [1, 2])
+    def test_alfven_mode_decay_rate(self, hyper_rz, scheme):
+        """Single Alfven mode at kz!=0: linear propagation is unitary, so |z|
+        isolates the kz damping factor exactly."""
+        grid = SpectralGrid3D.create(Nx=16, Ny=16, Nz=16)
+        kz_mode = 2.0
+        # M=0 keeps it fluid; small amplitude so nonlinearity is negligible
+        # (a single perpendicular mode has vanishing Poisson bracket anyway).
+        state = initialize_alfven_wave(grid, M=0, kz_mode=kz_mode, amplitude=1e-3)
+
+        eta_z = 1.0
+        dt = 0.01
+        n_steps = 50
+
+        current = state
+        for _ in range(n_steps):
+            current = gandalf_step(
+                current,
+                dt,
+                eta=0.0,
+                v_A=1.0,
+                nu=0.0,
+                eta_z=eta_z,
+                hyper_rz=hyper_rz,
+                scheme=scheme,
+            )
+
+        t = n_steps * dt
+        kz_max_sq = _kz_max_squared(grid)
+        expected = float(jnp.exp(-eta_z * (kz_mode**2 / kz_max_sq) ** hyper_rz * t))
+
+        for f0, f1 in [(state.z_plus, current.z_plus), (state.z_minus, current.z_minus)]:
+            amp0 = float(jnp.linalg.norm(f0))
+            amp1 = float(jnp.linalg.norm(f1))
+            assert amp0 > 0.0
+            assert amp1 / amp0 == pytest.approx(expected, rel=1e-2), (
+                f"kz damping decay mismatch (hyper_rz={hyper_rz}, scheme={scheme}): "
+                f"measured {amp1 / amp0:.6f}, expected {expected:.6f}"
+            )
+
+    def test_kz_zero_mode_unaffected(self):
+        """A kz=0 mode must not be damped by parallel dissipation."""
+        grid = SpectralGrid3D.create(Nx=16, Ny=16, Nz=16)
+        state = initialize_alfven_wave(grid, M=0, kz_mode=0.0, amplitude=1e-3)
+
+        current = state
+        for _ in range(20):
+            current = gandalf_step(
+                current, 0.01, eta=0.0, v_A=1.0, nu=0.0, eta_z=1.0, hyper_rz=2
+            )
+
+        amp0 = float(jnp.linalg.norm(state.z_plus))
+        amp1 = float(jnp.linalg.norm(current.z_plus))
+        assert amp1 / amp0 == pytest.approx(1.0, rel=1e-3)
+
+
+class TestKzDampingHermiteMoments:
+    """Hermite moments must be damped at the same kz-dependent rate, all m equally."""
+
+    @pytest.mark.parametrize("scheme", ["imex_rk222", "lawson_rk4"])
+    def test_g_damped_uniformly_across_moments(self, scheme):
+        """With z+-=0 the g evolution is linear and block-diagonal per kz, so the
+        damped run must equal the undamped run times the analytic kz factor,
+        identically for every Hermite moment m."""
+        grid = SpectralGrid3D.create(Nx=8, Ny=8, Nz=8)
+        M = 4
+        g = initialize_hermite_moments(grid, M=M, perturbation_amplitude=0.01)
+        zeros = jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64)
+        state = KRMHDState(
+            z_plus=zeros,
+            z_minus=zeros,
+            B_parallel=zeros,
+            g=g,
+            M=M,
+            beta_i=1.0,
+            v_th=1.0,
+            nu=0.0,
+            Lambda=1.0,
+            time=0.0,
+            grid=grid,
+        )
+        assert float(jnp.linalg.norm(state.g)) > 0.0
+
+        eta_z = 1.0
+        hyper_rz = 2
+        dt = 0.01
+        n_steps = 20
+
+        s_ref = state
+        s_damped = state
+        for _ in range(n_steps):
+            s_ref = gandalf_step(s_ref, dt, eta=0.0, v_A=1.0, nu=0.0, scheme=scheme)
+            s_damped = gandalf_step(
+                s_damped,
+                dt,
+                eta=0.0,
+                v_A=1.0,
+                nu=0.0,
+                eta_z=eta_z,
+                hyper_rz=hyper_rz,
+                scheme=scheme,
+            )
+
+        # z+- must remain zero (no spurious excitation)
+        assert jnp.allclose(s_damped.z_plus, 0.0, atol=1e-12)
+        assert jnp.allclose(s_damped.z_minus, 0.0, atol=1e-12)
+
+        t = n_steps * dt
+        kz_max_sq = _kz_max_squared(grid)
+        kz_3d = grid.kz[:, jnp.newaxis, jnp.newaxis]
+        expected_factor = jnp.exp(-eta_z * (kz_3d**2 / kz_max_sq) ** hyper_rz * t)
+
+        # Same factor for every moment m (broadcast across the trailing m-axis)
+        assert jnp.allclose(
+            s_damped.g,
+            s_ref.g * expected_factor[:, :, :, jnp.newaxis],
+            rtol=1e-3,
+            atol=1e-8,
+        ), f"g not damped by the analytic kz factor (scheme={scheme})"
+
+        # kz=0 plane untouched
+        assert jnp.allclose(s_damped.g[0], s_ref.g[0], rtol=1e-5, atol=1e-10)
+
+        # Streaming spread energy into moments beyond the seeded g_1, so the
+        # uniform-in-m check above is non-trivial: verify several moments are live.
+        moment_norms = jnp.sqrt(jnp.sum(jnp.abs(s_ref.g) ** 2, axis=(0, 1, 2)))
+        assert int(jnp.sum(moment_norms > 0)) >= 3
+
+
+class TestKzDampingValidation:
+    """Validation mirrors the existing perpendicular eta checks."""
+
+    @staticmethod
+    def _small_state():
+        grid = SpectralGrid3D.create(Nx=16, Ny=16, Nz=16)
+        return initialize_alfven_wave(grid, M=0, kz_mode=1.0, amplitude=1e-3)
+
+    def test_invalid_hyper_rz_raises(self):
+        state = self._small_state()
+        with pytest.raises(ValueError, match="hyper_rz"):
+            gandalf_step(state, 0.01, eta=0.0, v_A=1.0, nu=0.0, eta_z=0.1, hyper_rz=3)
+
+    def test_eta_z_overflow_raises(self):
+        state = self._small_state()
+        # eta_z * dt = 50 >= MAX_DAMPING_RATE_THRESHOLD
+        with pytest.raises(ValueError, match="overflow"):
+            gandalf_step(state, 0.01, eta=0.0, v_A=1.0, nu=0.0, eta_z=5000.0)
+
+    def test_eta_z_moderate_rate_warns(self):
+        state = self._small_state()
+        # eta_z * dt = 25 in [20, 50): RuntimeWarning, same thresholds as eta
+        with pytest.warns(RuntimeWarning, match="eta_z"):
+            gandalf_step(state, 0.01, eta=0.0, v_A=1.0, nu=0.0, eta_z=2500.0)
+
+    def test_eta_z_with_tiny_nz_raises(self):
+        """eta_z > 0 requires (Nz-1)//3 >= 1: normalized kz damping is undefined
+        when no nonzero kz mode exists inside the dealias boundary (original
+        GANDALF guarded dampz with `if (Nz > 1)`)."""
+        grid = SpectralGrid3D.create(Nx=32, Ny=32, Nz=2, Lx=1.0, Ly=1.0, Lz=1.0)
+        state = initialize_orszag_tang(grid, M=0)
+        with pytest.raises(ValueError, match="Nz"):
+            gandalf_step(state, 0.001, eta=0.0, v_A=1.0, nu=0.0, eta_z=0.1)


### PR DESCRIPTION
## Summary

Adds the missing **parallel (kz) hyper-dissipation** channel (audit finding F4). The original CUDA GANDALF applies this damping every step to the Elsasser fields and to every Hermite moment; the JAX port had no kz dissipation anywhere — nothing regulated the parallel spectrum except Hermite collisions in m.

Related to #136 and #137.

## Operator

Post-step multiplicative damping, applied to `z_plus`, `z_minus`, AND all Hermite moments `g`:

```
field *= exp( -eta_z * (kz^2 / kz_max^2)^hyper_rz * dt ),    kz_max = kz[(Nz-1)//3]
```

with `kz_max` at the 2/3 dealias boundary — the exact parallel analogue of the existing normalized perpendicular hyper-resistivity (`eta`, `hyper_r`, `k_perp_max` at `idx_max = (Nx-1)//3`, `idy_max = (Ny-1)//3`).

**Original-code references:**
- `damping_kernel.cu:4-33` — `dampz` kernel: `znew *= exp(-nu_kz*dt*pow(abs(kz(idz)/kz(idmax)), 2*alpha_z))` with `idmax = (Nz-1)/3`, guarded by `if(Nz>1)`
- `timestep.cu:94-108` — applied every step: `dampz(zpNew, nu_kz, alpha_z, dt)`, `dampz(zmNew, ...)`, and `dampz` on each `Gm` with `nu_kz_g`/`alpha_kz_g`

## API

Two new keyword arguments on `gandalf_step` (and on both JIT kernels):

- `eta_z: float = 0.0` — parallel hyper-resistivity coefficient (traced arg)
- `hyper_rz: int = 1` — parallel hyper-resistivity order, one of {1, 2, 4, 8} (static arg)

Applied at the same point in the post-step dissipation section of **both** `_gandalf_step_lawson_rk4_jit` and `_gandalf_step_imex222_jit`, so the two schemes stay equivalent (decay tests cover both).

**Deliberate deviation from the original:** the CUDA code used a separate coefficient `nu_kz_g` (order `alpha_kz_g`) for the Hermite moments. Here one coefficient `eta_z` (and one order `hyper_rz`) is shared by z± and g — exactly like the existing perpendicular `eta`, which is already shared across all three fields. Documented in the `gandalf_step` docstring.

**Default-off guarantee:** `eta_z=0.0` gives exactly zero behavior change (the damping factor is identically 1; verified bit-exact by `test_defaults_identical_to_explicit_zero`).

## Validation (mirrors the existing eta checks)

- `hyper_rz` must be in {1, 2, 4, 8}
- Overflow: `eta_z * dt < 50` (`MAX_DAMPING_RATE_THRESHOLD`) raises; `RuntimeWarning` above 20 (`DAMPING_RATE_WARNING_THRESHOLD`) — resolution-independent thanks to the normalization
- `eta_z > 0` with `(Nz-1)//3 < 1` raises `ValueError` (no nonzero kz mode inside the 2/3 dealias boundary; the original guarded `dampz` with `if(Nz>1)`)
- A **static** `if idz_max >= 1` branch in both kernels skips the block entirely for tiny Nz (e.g. Nz=2 used by 2D-style tests), preventing a `0 * inf = NaN` inside `exp` even when `eta_z=0`

## Tests (`tests/test_kz_damping.py`, written TDD-first — new file to avoid conflicts with parallel work)

- **No-op regression:** defaults vs explicit `eta_z=0.0, hyper_rz=1` produce identical fields (16^3, M=4, `initialize_random_spectrum`); Nz=2 grid runs without NaN under defaults
- **Decay rate:** single Alfven mode at kz=2 (M=0 fluid, small amplitude; linear propagation is unitary so |z| isolates the damping) decays by `exp(-eta_z*(kz^2/kz_max^2)^rz*t)` within 1%, parametrized over `hyper_rz` in {1, 2} x scheme in {imex_rk222, lawson_rk4}; kz=0 mode unaffected
- **Hermite moments:** with z± = 0 the g evolution is linear and block-diagonal per kz, so the damped run equals the undamped run times the analytic kz factor, uniformly across all moments (both schemes)
- **Validation:** `hyper_rz=3`, `eta_z*dt >= 50`, the 20-50 warning band, and `eta_z>0` on Nz=2 all raise/warn as specified

## Config plumbing

`eta_z` / `hyper_rz` added to `PhysicsConfig` (same field-validator pattern as `hyper_r`) and forwarded in `scripts/run_simulation.py`.

## Test results

- `tests/test_kz_damping.py`: **13 passed**
- `tests/test_kz_damping.py tests/test_timestepping.py tests/test_physics.py`: **164 passed, 1 skipped, 1 failed (pre-existing, see below)**
- Wider suite (`tests/` minus `test_modal.py` / `test_performance.py`): **626 passed, 1 skipped, 12 failed — all 12 known pre-existing on main**

**Pre-existing failures (not fixed here, not introduced by this PR):**
- `tests/test_physics.py::TestKRMHDState::test_energy_parseval_validation` — verified failing on a clean tree (git stash) before this change
- `tests/test_io.py` (4): `test_turbulence_diagnostics_roundtrip`, `test_turbulence_diagnostics_metadata_preservation`, `test_turbulence_diagnostics_empty_list`, `test_turbulence_diagnostics_compression`
- `tests/test_run_simulation.py` (7): `test_run_simulation_minimal`, `test_run_simulation_no_overwrite_error`, `test_run_simulation_with_overwrite`, `test_creates_nested_directories`, `test_empty_directory_reuse_allowed`, `test_moderate_cfl_violation_warns`, `test_checkpoint_interval_creates_checkpoints` — all from a pre-existing `UnboundLocalError: cannot access local variable 'np'` in `scripts/run_simulation.py` (the `import numpy as np` inside the `if config.forcing.enabled:` branch shadows the name for the whole function); verified the traceback is the same `np` error after this change
