### PR TITLE
Fix integrating-factor phase on Elsasser nonlinear increment

### DIFF
--- a/src/krmhd/timestepping.py
+++ b/src/krmhd/timestepping.py
@@ -9,8 +9,11 @@ Chapter 2, Equations 2.13-2.19:
 - Exponential integration for dissipation
 
 The integrating factor e^(±ikz*t) removes the stiff linear term. The Elsasser
-sector retains the thesis midpoint RK2 update, while the passive Hermite
-sector uses a Lawson-form RK4 update for stable externally driven advection.
+sector uses the midpoint RK2 update in the interaction picture (Lawson form):
+with w(s) = e^(∓ikz*s)·ξ±(s), dw/ds = e^(∓ikz*s)·NL, so each nonlinear
+increment is propagated by exactly one phase factor covering the remaining
+sub-interval. The passive Hermite sector uses a Lawson-form RK4 update for
+stable externally driven advection.
 
 Example usage:
     >>> grid = SpectralGrid3D.create(Nx=64, Ny=64, Nz=32)
@@ -453,7 +456,7 @@ def _gandalf_step_lawson_rk4_jit(
         return g_eigen @ streaming_P_T        # project back
 
     # =========================================================================
-    # Step 1: Elsasser half-step (thesis Eq. 2.14-2.17)
+    # Step 1: Elsasser half-step (integrating-factor predictor, cf. thesis §2.4)
     # =========================================================================
 
     # Compute initial RHS (with dissipation temporarily set to 0)
@@ -470,10 +473,16 @@ def _gandalf_step_lawson_rk4_jit(
     nl_plus_0 = rhs_0.z_plus - (1j * kz_3d * fields.z_plus)    # Subtract +ikz·z⁺
     nl_minus_0 = rhs_0.z_minus + (1j * kz_3d * fields.z_minus)  # Subtract -ikz·z⁻
 
-    # Half-step update: ξ±,n+1/2 = e^(±ikz·Δt/2) · [ξ±,n + e^(±ikz·Δt/2) · Δt/2 · NL^n]
-    # Note: the e^(±ikz·Δt/2) factor appears twice (thesis Eq. 2.14)
-    z_plus_half = phase_plus_half * (fields.z_plus + phase_plus_half * (dt / 2.0) * nl_plus_0)
-    z_minus_half = phase_minus_half * (fields.z_minus + phase_minus_half * (dt / 2.0) * nl_minus_0)
+    # Half-step update in the interaction picture (Lawson form): define
+    # w(s) = e^(∓ikz·s)·ξ±(s), so that dw/ds = e^(∓ikz·s)·NL(ξ±(s)).
+    # Forward-Euler predictor over [0, Δt/2] in w, mapped back to ξ±:
+    #   ξ±,n+1/2 = e^(±ikz·Δt/2) · [ξ±,n + Δt/2 · NL^n]
+    # The phase multiplies the whole bracket exactly ONCE. (An earlier version
+    # applied the phase a second time to the nonlinear increment, citing
+    # thesis Eq. 2.14; the original CUDA GANDALF (timestep.cu, alf_adv)
+    # applies linstep to the NL term exactly once, matching this form.)
+    z_plus_half = phase_plus_half * (fields.z_plus + (dt / 2.0) * nl_plus_0)
+    z_minus_half = phase_minus_half * (fields.z_minus + (dt / 2.0) * nl_minus_0)
 
     # Hermite RK4 stage 1: nonlinear-only RHS at t_n
     nl_g_1 = compute_nl_g(fields)
@@ -513,9 +522,16 @@ def _gandalf_step_lawson_rk4_jit(
     # Step 3: Full step using midpoint RHS (Elsasser) and RK4 stage assembly (Hermite)
     # =========================================================================
 
-    # Elsasser full step: ξ±,n+1 = e^(±ikz·Δt) · [ξ±,n + e^(±ikz·Δt) · Δt · NL^(n+1/2)]
-    z_plus_new = phase_plus_full * (fields.z_plus + phase_plus_full * dt * nl_plus_half)
-    z_minus_new = phase_minus_full * (fields.z_minus + phase_minus_full * dt * nl_minus_half)
+    # Elsasser full step (midpoint rule in the interaction picture):
+    #   w^(n+1) = w^n + Δt · e^(∓ikz·Δt/2) · NL^(n+1/2)
+    #   =>  ξ±,n+1 = e^(±ikz·Δt) · ξ±,n + e^(±ikz·Δt/2) · Δt · NL^(n+1/2)
+    # The half phase on the increment propagates the midpoint nonlinear
+    # transfer over the remaining half interval [Δt/2, Δt]. Note: the original
+    # CUDA GANDALF applied the full phase e^(±ikz·Δt) (once) to the corrector
+    # increment; the consistent Lawson midpoint uses e^(±ikz·Δt/2). The
+    # difference is an O(kz·Δt²) local term, so both are formally 2nd order.
+    z_plus_new = phase_plus_full * fields.z_plus + phase_plus_half * dt * nl_plus_half
+    z_minus_new = phase_minus_full * fields.z_minus + phase_minus_half * dt * nl_minus_half
 
     # Hermite RK4 stage 3: same midpoint Elsasser fields, updated Hermite state.
     g_stage_3 = g_base_half + (dt / 2.0) * nl_g_2
@@ -796,8 +812,11 @@ def _gandalf_step_imex222_jit(
     )
     nl_plus_0 = rhs_0.z_plus - (1j * kz_3d * fields.z_plus)
     nl_minus_0 = rhs_0.z_minus + (1j * kz_3d * fields.z_minus)
-    z_plus_half = phase_plus_half * (fields.z_plus + phase_plus_half * (dt / 2.0) * nl_plus_0)
-    z_minus_half = phase_minus_half * (fields.z_minus + phase_minus_half * (dt / 2.0) * nl_minus_0)
+    # Interaction-picture (Lawson) forward-Euler predictor over [0, Δt/2]:
+    # ξ±,n+1/2 = e^(±ikz·Δt/2)·[ξ±,n + Δt/2·NL^n] — single phase application;
+    # see the derivation in _gandalf_step_lawson_rk4_jit (identical block).
+    z_plus_half = phase_plus_half * (fields.z_plus + (dt / 2.0) * nl_plus_0)
+    z_minus_half = phase_minus_half * (fields.z_minus + (dt / 2.0) * nl_minus_0)
 
     # IMEX tableau stage 2 (c=gamma): N evaluated at (g^n, z+/-^n); u^(1)=g^n is trivial
     N_1 = compute_nl_g(fields)
@@ -822,9 +841,12 @@ def _gandalf_step_imex222_jit(
     nl_plus_half = rhs_half.z_plus - (1j * kz_3d * fields_half.z_plus)
     nl_minus_half = rhs_half.z_minus + (1j * kz_3d * fields_half.z_minus)
 
-    # Elsasser full-step (matches Lawson path exactly given same nl_plus/minus_half)
-    z_plus_new = phase_plus_full * (fields.z_plus + phase_plus_full * dt * nl_plus_half)
-    z_minus_new = phase_minus_full * (fields.z_minus + phase_minus_full * dt * nl_minus_half)
+    # Elsasser full-step: midpoint rule in the interaction picture,
+    # ξ±,n+1 = e^(±ikz·Δt)·ξ±,n + e^(±ikz·Δt/2)·Δt·NL^(n+1/2)
+    # (matches Lawson path exactly given same nl_plus/minus_half; see the
+    # derivation and CUDA-comparison note in _gandalf_step_lawson_rk4_jit)
+    z_plus_new = phase_plus_full * fields.z_plus + phase_plus_half * dt * nl_plus_half
+    z_minus_new = phase_minus_full * fields.z_minus + phase_minus_half * dt * nl_minus_half
 
     # IMEX tableau stage 3 (c=1): N at (g^(1), z+/-^{n+dt/2}).
     # rhs_half.g was evaluated with real kz (includes streaming); we need the

--- a/tests/test_timestepping.py
+++ b/tests/test_timestepping.py
@@ -25,6 +25,7 @@ from krmhd.physics import (
     initialize_alfven_wave,
     initialize_hermite_moments,
     initialize_orszag_tang,
+    initialize_random_spectrum,
     energy,
 )
 from krmhd.timestepping import krmhd_rhs, gandalf_step, compute_cfl_timestep
@@ -557,6 +558,73 @@ class TestConvergence:
             avg_rate = jnp.mean(jnp.array(convergence_rates))
             assert avg_rate > 1.5, \
                 f"Average convergence rate p={avg_rate:.2f} too low (expected >1.5 for RK2)"
+
+    def test_second_order_convergence_nonlinear_3d(self):
+        """Verify O(dt²) convergence with an active nonlinearity at kz != 0.
+
+        The single-Alfvén-wave test above has an identically vanishing
+        Poisson bracket, so it only exercises the (exact) linear integrating
+        factor and is blind to errors in how the nonlinear increment is
+        combined with the phase factors. This test uses a random 3D spectrum
+        (kz != 0 modes with order-unity nonlinearity) so that the
+        linear-nonlinear cross coupling dominates the time-discretization
+        error.
+
+        Regression test for audit finding F2: the Elsasser update applied the
+        integrating-factor phase twice to the nonlinear increment
+        (e^(2i·kz·dt)·dt·NL instead of e^(i·kz·dt/2)·dt·NL), which degraded
+        the scheme to 1st order in the kz-dependent phase of every nonlinear
+        transfer while leaving 2D (kz=0) benchmarks untouched.
+        """
+        grid = SpectralGrid3D.create(Nx=32, Ny=32, Nz=16)
+        v_A = 1.0
+        eta = 0.0  # Inviscid: isolate time-integration error
+        scheme = "imex_rk222"  # Pin scheme (both share the Elsasser update)
+
+        def make_state():
+            # M=0 (pure fluid) isolates the Elsasser sector; nu=0 required for M=0.
+            # amplitude=1000 gives order-unity REAL-SPACE fields (the spectral
+            # coefficients returned by initialize_random_spectrum carry the
+            # 1/N^3 irfft normalization, so amplitude=1 real-space fields are
+            # ~1e-3): the nonlinear rate is then O(1) and the O(dt^2)
+            # truncation error sits well above the complex64 accumulation
+            # floor at the smallest dt tested, while CFL ~ 0.3 at dt=0.02.
+            return initialize_random_spectrum(
+                grid, M=0, alpha=5/3, amplitude=1000.0,
+                k_min=1.0, k_max=3.0, nu=0.0, seed=42,
+            )
+
+        t_final = 0.2
+
+        # Reference solution with a very small timestep
+        dt_ref = 1e-3
+        state_ref = make_state()
+        for _ in range(round(t_final / dt_ref)):
+            state_ref = gandalf_step(state_ref, dt_ref, eta=eta, v_A=v_A, scheme=scheme)
+        z_plus_ref = state_ref.z_plus
+
+        timesteps = [0.02, 0.01, 0.005]
+        errors = []
+        for dt in timesteps:
+            state = make_state()
+            for _ in range(round(t_final / dt)):
+                state = gandalf_step(state, dt, eta=eta, v_A=v_A, scheme=scheme)
+            error = jnp.sqrt(jnp.mean(jnp.abs(state.z_plus - z_plus_ref) ** 2))
+            errors.append(float(error))
+
+        # Consecutive convergence orders p = log(e_i/e_{i+1}) / log(dt_i/dt_{i+1})
+        rates = []
+        for i in range(len(errors) - 1):
+            p = np.log(errors[i] / errors[i + 1]) / np.log(timesteps[i] / timesteps[i + 1])
+            rates.append(float(p))
+        avg_rate = float(np.mean(rates))
+
+        assert avg_rate > 1.7, (
+            f"Nonlinear 3D convergence order p={avg_rate:.2f} too low "
+            f"(expected ~2 for the integrating-factor RK2 midpoint scheme; "
+            f"p~1 indicates a phase error on the nonlinear increment). "
+            f"errors={errors}, rates={rates}"
+        )
 
 
 class TestHermiteMomentIntegration:


### PR DESCRIPTION
## Summary

Fixes a verified time-integration defect (audit finding F2): both Elsasser kernels
(`_gandalf_step_lawson_rk4_jit` and `_gandalf_step_imex222_jit`) applied the
integrating-factor phase **twice** to the nonlinear increment, degrading the scheme to
formally 1st order in the linear-nonlinear cross coupling for every `kz != 0` mode.

With `theta = kz*dt` (per mode):

**Before (buggy)**

- half step: `z_half = e^(i*theta/2) * (z + e^(i*theta/2) * (dt/2) * NL0)` = `e^(i*theta/2)*z + e^(i*theta)*(dt/2)*NL0`
- full step: `z_new = e^(i*theta) * (z + e^(i*theta) * dt * NL_half)` = `e^(i*theta)*z + e^(2i*theta)*dt*NL_half`

**After (consistent Lawson / interaction-picture midpoint RK2)**

- half step: `z_half = e^(i*theta/2) * (z + (dt/2) * NL0)`
- full step: `z_new = e^(i*theta)*z + e^(i*theta/2)*dt*NL_half`

## Derivation

Define the interaction-picture variable `w(s) = e^(-i*kz*s) * z(s)`, which removes the
(exactly integrable) linear propagation term, leaving `dw/ds = e^(-i*kz*s) * N(z(s))`.

- Predictor (forward Euler over `[0, dt/2]`): `w(dt/2) = w0 + (dt/2)*N0`
  => `z_half = e^(i*theta/2) * (z + (dt/2)*NL0)` — a **single** phase multiplying the
  whole bracket.
- Corrector (midpoint rule over `[0, dt]`): `w(dt) = w0 + dt * e^(-i*theta/2) * N(z_half)`
  => `z_new = e^(i*theta)*z + e^(i*theta/2)*dt*NL_half`.

Each nonlinear increment is propagated by exactly one phase factor covering the
remaining sub-interval.

## Comparison with the original CUDA GANDALF

In `timestep.cu` (`alf_adv`), the original code applies `linstep` to the NL term
**once** and to the field once, then `fwdeuler`:

```
linstep(temp3, temp3, dt);   // NL term * e^(i*kz*dt)   — ONCE
linstep(zpNew, zpOld, dt);   // zpNew = zpOld * e^(i*kz*dt)
fwdeuler(zpNew, temp3, dt);  // zpNew += dt * temp3
```

i.e. `z_new = e^(i*theta)*z + e^(i*theta)*dt*NL`. The removed JAX code
(`e^(2i*theta)` on the corrector increment) matched **neither** the CUDA reference
**nor** the consistent Lawson form — the code comment attributing the doubled factor
to "thesis Eq. 2.14" contradicted the validated CUDA implementation. In the half step
(`alf_adv` called with `dt/2`) the CUDA form coincides exactly with the consistent
Lawson predictor implemented here.

This PR implements the consistent Lawson form. The corrector phase differs from the
CUDA reference (`e^(i*theta/2)` here vs `e^(i*theta)` there); that difference is an
O(kz*dt^2) **local** term, so both are formally 2nd order — the CUDA choice was itself
a small local inconsistency, while the removed doubled factor produced an O(kz*dt)
**global** error. This is documented in the kernel comments.

## Impact of the bug

- **Unitary**: `|e^(i*phi)| = 1`, so there was **no amplitude error** — energy
  conservation and dissipation tests could not see it.
- **Phase skew**: every nonlinear transfer acquired a systematic kz-dependent phase
  error `~ e^(3i*kz*dt/2)`, order-1 radian at the dealiased kz max under CFL 0.3 at
  128^3.
- **Order reduction**: global convergence degraded to 1st order in the
  linear-nonlinear cross coupling (measured p ~ 1.1, see below).
- **2D-blind**: the error vanishes identically for `kz = 0`, which is why all 2D
  benchmarks (e.g. Orszag-Tang) passed. The existing `test_second_order_convergence`
  uses a single Alfven wave whose Poisson bracket vanishes identically, so it was
  also blind to this defect.

## Measured convergence order

New regression test `test_second_order_convergence_nonlinear_3d` (random 3D spectrum,
M=0 pure fluid, eta=0, 32x32x16, t_final=0.2, reference dt=1e-3, `imex_rk222`;
L2 error of `z_plus` at dt = [0.02, 0.01, 0.005]):

| | L2 errors | consecutive orders | mean p |
|---|---|---|---|
| **before** | 7.56e-1, 3.57e-1, 1.59e-1 | 1.08, 1.17 | **1.13** |
| **after** | 3.43e-2, 8.46e-3, 2.06e-3 | 2.02, 2.04 | **2.03** |

(The before-fix orders 1.08/1.17 match the analytic prediction
`log2((dt_i - dt_ref)/(dt_{i+1} - dt_ref))` for a globally 1st-order scheme measured
against a small-dt reference.) The test asserts mean p > 1.7 and fails at p = 1.13 on
the unfixed code. Error at dt=0.02 drops 22x with the fix.

Both kernels' Elsasser update lines remain textually identical to each other, so the
imex-vs-lawson trajectory-agreement tests (`test_imex222_nontrivial_vA_matches_lawson`,
`test_imex222_fluid_limit_regression`, `test_imex222_bparallel_parity_with_lawson`)
still pass unchanged. The Hermite/g Lawson-RK4 path already had the correct
single-phase structure and is untouched. Linear behavior is unchanged
(`test_alfven_wave_frequency` and dissipation tests pass: the integrating factor on
the field itself was and remains exact).

## Test results

- Targeted (`tests/test_timestepping.py tests/test_physics.py tests/test_hermite.py
  tests/test_hermite_closures.py`): **212 passed, 1 skipped, 1 failed** (the
  pre-existing Parseval failure below).
- Wider suite (`tests/` minus `test_modal.py`, `test_performance.py`):
  **614 passed, 1 skipped, 12 failed**.
- All 12 failures were verified to fail identically on clean `main` @ 4558b96
  (re-ran with this branch's changes stashed) — **no new failures** from this change.
  Pre-existing failures, left as-is:
  - `tests/test_io.py`: 4x `test_turbulence_diagnostics_*` (save/load of turbulence
    diagnostics)
  - `tests/test_physics.py::TestKRMHDState::test_energy_parseval_validation`
  - `tests/test_run_simulation.py`: 7 failures (`UnboundLocalError` on `np` in
    `scripts/run_simulation.py` — a function-local `import numpy as np` shadows the
    module-level import)

## Related

Related to #136 — the bug's signature (3D-only, kz-dependent, amplitude-preserving
phase skew on nonlinear transfers) makes it a plausible contributor to the slow
secular pileup seen only in long 3D forced runs. Suggest rerunning the 128^3
reproduction after merge.
