### PR TITLE
Remove dead B_parallel field and force_slow_modes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,15 +16,17 @@ The user is an expert plasma physicist familiar with gyrokinetics, Landau dampin
   - These drive the turbulent cascade
   
 - **Passive (slow mode) sector**:
-  - Parallel magnetic field perturbation δB∥
-  - Electron density/pressure perturbations n_e, p_e
+  - Electron density/pressure perturbations n_e, p_e (via Hermite moments)
   - These are advected by Alfvénic turbulence but don't back-react
+  - The compressive/slow-mode observables (δn_e, δB∥) are derived from the
+    Hermite hierarchies with the kinetic parameters Λ± (thesis; dne_dbpar.cu
+    postprocessor in the original GANDALF) rather than evolved as independent
+    fields
 
 ### Key Equations
 
 ```
 ∂A∥/∂t + {φ, A∥} = -∇∥φ + η∇²A∥
-∂δB∥/∂t + {φ, δB∥} = -∇∥u∥ + D∇²δB∥
 ∂n_e/∂t + {φ, n_e} = -∇∥u∥ + Landau damping terms
 ```
 where {f,g} = ẑ·(∇f × ∇g) is the Poisson bracket.
@@ -68,7 +70,7 @@ RMHD is an asymptotic expansion in the small parameter ε:
 **Field Normalization:**
 - **Magnetic field**: B = B₀ẑ + δB where δB comes from perturbations
   - Perpendicular: δB⊥ = ∇ × (Ψ ẑ) with Ψ = (z⁺ - z⁻)/2
-  - Parallel: Bz = 1 + δB∥ (state.B_parallel in Fourier space)
+  - Parallel: Bz = 1 (δB∥ is a derived diagnostic, not an evolved field)
 - **Field line following**: Requires full B field, so B₀ must be added in real space
 - **Important**: Never add constants in Fourier space - only k=0 mode is affected!
 
@@ -140,7 +142,7 @@ checkpoints to return to.
 - 128³ resolution should run efficiently on M1 Pro (matches original GANDALF)
 
 ### Energy Conservation
-- Alfven energy E = E_magnetic + E_kinetic. Slow modes are conserved separately: E_compressive
+- Alfven energy E = E_magnetic + E_kinetic
 - GANDALF formulation conserves perpendicular gradient energy exactly
 - Inviscid (η=0) runs: ~0.0086% relative error (200× better than simplified formulation)
 - Viscous (η>0) runs: Exponential energy decay E(t) = E₀ exp(-2ηk⊥²t)

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ The KRMHD model splits plasma dynamics into two coupled sectors:
 - These fields drive the turbulent energy cascade
 
 ### Passive (Slow Mode) Sector
-- **Parallel magnetic field delta_B_parallel**: Field-aligned magnetic fluctuations
-- **Electron density/pressure n_e, p_e**: Thermodynamic perturbations
+- **Electron density/pressure n_e, p_e**: Thermodynamic perturbations (via Hermite moments)
 - Advected by Alfvenic turbulence without back-reaction
+- The compressive observables (delta_n_e, delta_B_parallel) are derived
+  diagnostics of the Lambda+/- Hermite hierarchies (thesis; dne_dbpar.cu in
+  the original GANDALF), not independently evolved fields
 
 Key physical processes include:
 - Poisson bracket nonlinearities: `{f,g} = z_hat · (grad_f x grad_g)`
@@ -1191,7 +1193,7 @@ The code includes validation against:
 - **Forcing mechanisms** (Issue #29): Gaussian white noise forcing for driven turbulence
   - gaussian_white_noise_fourier(): Band-limited stochastic forcing
   - force_alfven_modes(): Forces z⁺=z⁻ identically (drives u⊥ only, not B⊥)
-  - force_slow_modes(): Independent forcing for δB∥
+  - force_hermite_moments(): Independent forcing for kinetic moments g_m
   - compute_energy_injection_rate(): Energy diagnostics for balance validation
   - Hermitian symmetry enforcement for rfft format (critical for direct Fourier operations)
 - **Validation examples** (Issues #11-12, #27): Physics benchmarks

--- a/examples/benchmarks/hermite_cascade_benchmark.py
+++ b/examples/benchmarks/hermite_cascade_benchmark.py
@@ -398,7 +398,6 @@ def main():
         state = KRMHDState(
             z_plus=jnp.zeros((Nz, Ny, Nx//2+1), dtype=complex),
             z_minus=jnp.zeros((Nz, Ny, Nx//2+1), dtype=complex),
-            B_parallel=jnp.zeros((Nz, Ny, Nx//2+1), dtype=complex),
             g=jnp.zeros((Nz, Ny, Nx//2+1, M+1), dtype=complex),
             grid=grid,
             time=0.0,

--- a/examples/benchmarks/hermite_forward_backward_flux.py
+++ b/examples/benchmarks/hermite_forward_backward_flux.py
@@ -171,7 +171,6 @@ def main():
     state = KRMHDState(
         z_plus=jnp.zeros((Nz, Ny, Nx//2+1), dtype=complex),
         z_minus=jnp.zeros((Nz, Ny, Nx//2+1), dtype=complex),
-        B_parallel=jnp.zeros((Nz, Ny, Nx//2+1), dtype=complex),
         g=jnp.zeros((Nz, Ny, Nx//2+1, M+1), dtype=complex),
         grid=grid,
         time=0.0,

--- a/examples/benchmarks/hermite_spectrum_evolution.py
+++ b/examples/benchmarks/hermite_spectrum_evolution.py
@@ -70,7 +70,6 @@ def main():
     state = KRMHDState(
         z_plus=jnp.zeros((Nz, Ny, Nx//2+1), dtype=complex),
         z_minus=jnp.zeros((Nz, Ny, Nx//2+1), dtype=complex),
-        B_parallel=jnp.zeros((Nz, Ny, Nx//2+1), dtype=complex),
         g=jnp.zeros((Nz, Ny, Nx//2+1, M+1), dtype=complex),
         grid=grid,
         time=0.0,

--- a/examples/validation/grid_convergence_tests.py
+++ b/examples/validation/grid_convergence_tests.py
@@ -125,7 +125,6 @@ def analytical_alfven_solution(
     return KRMHDState(
         z_plus=z_plus_t,
         z_minus=z_minus_t,
-        B_parallel=state0.B_parallel,
         g=state0.g,
         M=state0.M,
         beta_i=state0.beta_i,
@@ -339,7 +338,6 @@ def test_orszag_tang_convergence(
         # This properly handles negative frequency modes in y and z directions
         z_plus_ref_coarse = spectral_downsample(state_ref.z_plus, target_shape)
         z_minus_ref_coarse = spectral_downsample(state_ref.z_minus, target_shape)
-        B_parallel_ref_coarse = spectral_downsample(state_ref.B_parallel, target_shape)
 
         # For Hermite moments g (shape: [Nz, Ny, Nx//2+1, M+1]), downsample spatial dimensions
         # Note: Last dimension (M+1) is velocity space, not spatial
@@ -353,7 +351,6 @@ def test_orszag_tang_convergence(
         state_ref_coarse = KRMHDState(
             z_plus=z_plus_ref_coarse,
             z_minus=z_minus_ref_coarse,
-            B_parallel=B_parallel_ref_coarse,
             g=g_ref_coarse,
             M=state_ref.M,
             beta_i=state_ref.beta_i,

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -134,7 +134,6 @@ Energy history is saved as a Python pickle file containing:
     'E_total': np.array,      # Total energy
     'E_magnetic': np.array,   # Magnetic energy
     'E_kinetic': np.array,    # Kinetic energy
-    'E_compressive': np.array,# Compressive energy
     'v_A': float,             # Alfvén velocity
     'Lx': float,              # Domain size
 }

--- a/scripts/plot_checkpoint_spectrum.py
+++ b/scripts/plot_checkpoint_spectrum.py
@@ -118,11 +118,9 @@ def main():
     # The energy() function computes volume integrals of:
     # - Kinetic: E_kin = ∫ |∇⊥φ|²/2 dV (perpendicular flow energy)
     # - Magnetic: E_mag = ∫ |∇⊥A∥|²/2 dV (perpendicular field energy)
-    # - Compressive: E_comp = ∫ |δB∥|²/2 dV (parallel field perturbations)
     energy_dict = energy(state)
     E_mag = energy_dict["magnetic"]
     E_kin = energy_dict["kinetic"]
-    E_comp = energy_dict["compressive"]
     E_total = energy_dict["total"]
     f_mag = E_mag / E_total if E_total > 0 else 0.0
 

--- a/scripts/plot_energy_evolution.py
+++ b/scripts/plot_energy_evolution.py
@@ -85,7 +85,6 @@ def run_orszag_tang_simulation(save_file: str = "orszag_tang_history.pkl"):
         'E_total': np.array(history.E_total),
         'E_magnetic': np.array(history.E_magnetic),
         'E_kinetic': np.array(history.E_kinetic),
-        'E_compressive': np.array(history.E_compressive),
         'v_A': v_A,
         'Lx': Lx,
     }

--- a/src/krmhd/__init__.py
+++ b/src/krmhd/__init__.py
@@ -6,7 +6,11 @@ with kinetic effects such as Landau damping and finite Larmor radius corrections
 
 The KRMHD model describes the evolution of:
 - Active (Alfvénic) fields: stream function φ and parallel vector potential A∥
-- Passive (slow mode) fields: parallel magnetic field δB∥ and electron density/pressure
+- Kinetic sector: Hermite moments g_m of the electron distribution
+
+The compressive/slow-mode observables (δn_e, δB∥) are derived diagnostics of
+the Λ± Hermite hierarchies (thesis; dne_dbpar.cu in the original GANDALF),
+not independently evolved fields.
 
 Key features:
 - Fourier spectral methods (2D and 3D) with 2/3 dealiasing
@@ -90,7 +94,6 @@ from krmhd.forcing import (
     force_alfven_modes_gandalf,
     force_alfven_modes_balanced,
     force_alfven_modes_specific,
-    force_slow_modes,
     force_hermite_moments,
     force_hermite_moments_specific,
     compute_energy_injection_rate,
@@ -176,7 +179,6 @@ __all__ = [
     "gaussian_white_noise_fourier",
     "force_alfven_modes",
     "force_alfven_modes_balanced",
-    "force_slow_modes",
     "force_hermite_moments",
     "force_hermite_moments_specific",
     "compute_energy_injection_rate",

--- a/src/krmhd/config.py
+++ b/src/krmhd/config.py
@@ -462,7 +462,6 @@ class SimulationConfig(BaseModel):
             return KRMHDState(
                 z_plus=zeros_3d,
                 z_minus=zeros_3d,
-                B_parallel=zeros_3d,
                 g=zeros_moments,
                 M=M,
                 beta_i=self.physics.beta_i,

--- a/src/krmhd/diagnostics.py
+++ b/src/krmhd/diagnostics.py
@@ -1411,13 +1411,13 @@ def compute_magnetic_field_components(
 
     Computes the full 3D magnetic field including:
     - Perpendicular components from vector potential: B⊥ = ∇ × (Ψ ẑ)
-    - Parallel component: Bz = B₀ + δB∥
+    - Parallel component: Bz = B₀ (uniform guide field)
 
     All components are computed on a spectrally-padded fine grid for
     accurate field line following.
 
     Args:
-        state: KRMHD state with z_plus, z_minus, B_parallel
+        state: KRMHD state with z_plus, z_minus
         padding_factor: Resolution increase factor (default: 2)
 
     Returns:
@@ -1426,13 +1426,19 @@ def compute_magnetic_field_components(
 
     Physics:
         The magnetic field in RMHD:
-        B = B₀ẑ + δB
+        B = B₀ẑ + δB⊥
 
-        where δB comes from:
+        where:
         - B⊥ = ∇ × (Ψ ẑ) = (∂yΨ, -∂xΨ, 0)
-        - Bz = B₀ + δB∥
+        - Bz = B₀ (the δB∥ fluctuation is taken to be zero)
 
         Here Ψ = (z⁺ - z⁻)/2 is the parallel vector potential (up to normalization).
+
+        Note: δB∥ is not an evolved field in this formulation — it is a
+        derived diagnostic of the Λ± Hermite hierarchies (thesis;
+        dne_dbpar.cu in the original GANDALF), not yet implemented. Field
+        line following therefore uses Bz = B₀ exactly. This is consistent
+        with the RMHD ordering, where δB∥/B₀ = O(ε).
 
         Note: In the normalized equations, B₀ may not appear explicitly, but
         for field line following we need the full field direction.
@@ -1462,11 +1468,9 @@ def compute_magnetic_field_components(
     Bx_fine = spectral_pad_and_ifft(Bx_fourier, padding_factor)
     By_fine = spectral_pad_and_ifft(By_fourier, padding_factor)
 
-    # Parallel component: Bz = B₀ + δB∥
-    # Transform δB∥ to real space, then add B₀ = 1 (in normalized units)
-    # Note: Cannot add constant in Fourier space (only affects k=0 mode)
-    dBz_fine = spectral_pad_and_ifft(state.B_parallel, padding_factor)
-    Bz_fine = 1.0 + dBz_fine  # B₀ = 1 in code units
+    # Parallel component: Bz = B₀ (δB∥ is not an evolved field in this
+    # formulation; the fluctuation is identically zero here)
+    Bz_fine = jnp.ones_like(Bx_fine)  # B₀ = 1 in code units
 
     return {
         'Bx': Bx_fine,
@@ -1683,14 +1687,13 @@ class EnergyHistory:
     """
     Track energy evolution E(t) during KRMHD simulation.
 
-    Stores time series of all energy components (magnetic, kinetic, compressive)
+    Stores time series of all energy components (magnetic, kinetic)
     for analyzing energy conservation, dissipation rates, and equilibration.
 
     Attributes:
         times: List of simulation times
         E_magnetic: List of magnetic energy values
         E_kinetic: List of kinetic energy values
-        E_compressive: List of compressive energy values
         E_total: List of total energy values
 
     Example:
@@ -1713,7 +1716,6 @@ class EnergyHistory:
     times: List[float] = field(default_factory=list)
     E_magnetic: List[float] = field(default_factory=list)
     E_kinetic: List[float] = field(default_factory=list)
-    E_compressive: List[float] = field(default_factory=list)
     E_total: List[float] = field(default_factory=list)
 
     def append(self, state: KRMHDState) -> None:
@@ -1730,7 +1732,6 @@ class EnergyHistory:
         self.times.append(state.time)
         self.E_magnetic.append(energies['magnetic'])
         self.E_kinetic.append(energies['kinetic'])
-        self.E_compressive.append(energies['compressive'])
         self.E_total.append(energies['total'])
 
     def to_dict(self) -> Dict[str, List[float]]:
@@ -1750,7 +1751,6 @@ class EnergyHistory:
             'times': self.times,
             'E_magnetic': self.E_magnetic,
             'E_kinetic': self.E_kinetic,
-            'E_compressive': self.E_compressive,
             'E_total': self.E_total,
         }
 
@@ -1893,8 +1893,8 @@ def plot_energy_history(
     """
     Plot energy evolution E(t) from EnergyHistory.
 
-    Shows time series of all energy components (magnetic, kinetic, compressive,
-    total) on same axes for comparison.
+    Shows time series of all energy components (magnetic, kinetic, total)
+    on same axes for comparison.
 
     Args:
         history: EnergyHistory object with recorded time series
@@ -1912,19 +1912,16 @@ def plot_energy_history(
         - Conservation: E_total constant (inviscid) or exponential decay (viscous)
         - Selective decay: E_magnetic/E_kinetic increases over time
         - Equilibration: E_kinetic → E_magnetic for Alfvén waves
-        - Compressive energy should remain small in RMHD (passive)
     """
     times = np.array(history.times)
     E_mag = np.array(history.E_magnetic)
     E_kin = np.array(history.E_kinetic)
-    E_comp = np.array(history.E_compressive)
     E_tot = np.array(history.E_total)
 
     fig, ax = plt.subplots(figsize=figsize)
 
     ax.plot(times, E_mag, 'b-', label='Magnetic', linewidth=2)
     ax.plot(times, E_kin, 'r-', label='Kinetic', linewidth=2)
-    ax.plot(times, E_comp, 'g-', label='Compressive', linewidth=2)
     ax.plot(times, E_tot, 'k--', label='Total', linewidth=2)
 
     ax.set_xlabel('Time', fontsize=12)

--- a/src/krmhd/forcing.py
+++ b/src/krmhd/forcing.py
@@ -8,7 +8,7 @@ energy at large scales while allowing inertial-range cascade to develop.
 Key features:
 - Band-limited forcing: inject energy only at modes n ∈ [n_min, n_max]
 - Alfvén sector forcing: drives perpendicular velocity u⊥ only, NOT δB⊥
-- Slow mode forcing: optional independent forcing for δB∥ and kinetic moments
+- Hermite moment forcing: optional independent forcing for kinetic moments g_m
 - Energy injection rate diagnostics for monitoring energy balance
 
 Physics context:
@@ -503,7 +503,6 @@ def force_alfven_modes_balanced(
     new_state = KRMHDState(
         z_plus=z_plus_new,
         z_minus=z_minus_new,
-        B_parallel=state.B_parallel,
         g=state.g,
         M=state.M,
         beta_i=state.beta_i,
@@ -698,7 +697,6 @@ def force_alfven_modes(
     new_state = KRMHDState(
         z_plus=z_plus_new,
         z_minus=z_minus_new,
-        B_parallel=state.B_parallel,  # Passive field, not forced here
         g=state.g,  # Kinetic moments, not forced here
         M=state.M,
         beta_i=state.beta_i,
@@ -775,7 +773,6 @@ def force_alfven_modes_gandalf(
     new_state = KRMHDState(
         z_plus=z_plus_new,
         z_minus=z_minus_new,
-        B_parallel=state.B_parallel,
         g=state.g,
         M=state.M,
         beta_i=state.beta_i,
@@ -1035,82 +1032,7 @@ def force_alfven_modes_specific(
     new_state = KRMHDState(
         z_plus=z_plus_new,
         z_minus=z_minus_new,
-        B_parallel=state.B_parallel,
         g=state.g,
-        M=state.M,
-        beta_i=state.beta_i,
-        v_th=state.v_th,
-        nu=state.nu,
-        Lambda=state.Lambda,
-        time=state.time,
-        grid=state.grid,
-    )
-
-    return new_state, key
-
-
-def force_slow_modes(
-    state: KRMHDState,
-    amplitude: float,
-    n_min: int,
-    n_max: int,
-    dt: float,
-    key: Array,
-) -> Tuple[KRMHDState, Array]:
-    """
-    Apply Gaussian white noise forcing to slow modes (parallel magnetic field δB∥).
-
-    This forcing is INDEPENDENT from Alfvén forcing and drives compressive/slow
-    magnetosonic fluctuations. In KRMHD, slow modes are passively advected by
-    the Alfvén flow, but can be independently forced for studying their dynamics.
-
-    Args:
-        state: Current KRMHD state
-        amplitude: Forcing amplitude for slow modes
-        n_min: Minimum mode number for forcing band (typically n=1 or n=2)
-        n_max: Maximum mode number for forcing band (typically n=2 to n=5)
-        dt: Timestep size
-        key: JAX random key
-
-    Returns:
-        new_state: State with forcing applied to B∥
-        new_key: Updated random key
-
-    Example:
-        >>> key = jax.random.PRNGKey(42)
-        >>> # Force slow modes at large scales
-        >>> state_forced, key = force_slow_modes(
-        ...     state, amplitude=0.05, n_min=1, n_max=3, dt=0.01, key=key
-        ... )
-
-    Physics:
-        Slow modes in KRMHD satisfy:
-        ∂δB∥/∂t + {φ, δB∥} = -∇∥u∥ + D∇²δB∥ + F_slow
-
-        The forcing F_slow is uncorrelated with Alfvén forcing and allows
-        studying passive scalar advection, intermittency, and compressive effects.
-
-        Mode number convention: n=1 is the fundamental mode (k=2π/L),
-        n=2 is the second harmonic (k=4π/L), etc.
-    """
-    # Input validation (gaussian_white_noise_fourier validates n_min, n_max, dt)
-    if amplitude <= 0:
-        raise ValueError(f"amplitude must be positive, got {amplitude}")
-
-    # Generate forcing field for B∥
-    forcing, key = gaussian_white_noise_fourier(
-        state.grid, amplitude, n_min, n_max, dt, key
-    )
-
-    # Apply forcing to parallel magnetic field
-    B_parallel_new = state.B_parallel + forcing
-
-    # Create new state
-    new_state = KRMHDState(
-        z_plus=state.z_plus,  # Alfvén modes unchanged
-        z_minus=state.z_minus,
-        B_parallel=B_parallel_new,  # Forced slow mode
-        g=state.g,  # Kinetic moments unchanged
         M=state.M,
         beta_i=state.beta_i,
         v_th=state.v_th,
@@ -1231,7 +1153,6 @@ def force_hermite_moments(
     new_state = KRMHDState(
         z_plus=state.z_plus,  # Alfvén modes unchanged
         z_minus=state.z_minus,
-        B_parallel=state.B_parallel,  # Slow modes unchanged
         g=g_new,  # Forced Hermite moments
         M=state.M,
         beta_i=state.beta_i,
@@ -1388,7 +1309,6 @@ def force_hermite_moments_specific(
     new_state = KRMHDState(
         z_plus=state.z_plus,
         z_minus=state.z_minus,
-        B_parallel=state.B_parallel,
         g=g_new,
         M=state.M,
         beta_i=state.beta_i,

--- a/src/krmhd/io.py
+++ b/src/krmhd/io.py
@@ -48,7 +48,6 @@ File format:
     Checkpoint files contain:
     - /state/z_plus: Complex Elsasser field (stored as real + imag)
     - /state/z_minus: Complex Elsasser field (stored as real + imag)
-    - /state/B_parallel: Complex parallel magnetic field (stored as real + imag)
     - /state/g: Complex Hermite moments (stored as real + imag)
     - /state attributes: M, beta_i, v_th, nu, Lambda, time
     - /grid attributes: Nx, Ny, Nz, Lx, Ly, Lz
@@ -58,9 +57,16 @@ File format:
     - /times: Time array
     - /E_magnetic: Magnetic energy time series
     - /E_kinetic: Kinetic energy time series
-    - /E_compressive: Compressive energy time series
     - /E_total: Total energy time series
     - attributes: Creation timestamp, version
+
+Backward compatibility:
+    Checkpoints written before the removal of the (never-evolved) B_parallel
+    field additionally contain /state/B_parallel_real and
+    /state/B_parallel_imag datasets, and old timeseries files contain an
+    /E_compressive dataset. Both are silently ignored on load; the format
+    version attribute (IO_FORMAT_VERSION) was intentionally left unchanged
+    because old files remain fully readable.
 
 Physics context:
     Checkpointing is essential for long turbulence runs (t >> τ_nl) where:
@@ -107,7 +113,7 @@ def save_checkpoint(
     """
     Save KRMHD state to HDF5 checkpoint file.
 
-    Saves complete simulation state including all fields (z±, B∥, g), physical
+    Saves complete simulation state including all fields (z±, g), physical
     parameters (β_i, v_th, ν, Λ), grid configuration, and optional metadata.
     Complex arrays are stored as separate real/imaginary parts.
 
@@ -143,7 +149,6 @@ def save_checkpoint(
     File structure:
         /state/z_plus_real, z_plus_imag: Elsasser z+ field
         /state/z_minus_real, z_minus_imag: Elsasser z- field
-        /state/B_parallel_real, B_parallel_imag: Parallel B field
         /state/g_real, g_imag: Hermite moments
         /state (attributes): M, beta_i, v_th, nu, Lambda, time
         /grid (attributes): Nx, Ny, Nz, Lx, Ly, Lz
@@ -173,7 +178,6 @@ def save_checkpoint(
     # Convert JAX arrays to NumPy for h5py compatibility
     z_plus = np.array(state.z_plus)
     z_minus = np.array(state.z_minus)
-    B_parallel = np.array(state.B_parallel)
     g = np.array(state.g)
 
     # Validate complex dtypes
@@ -210,19 +214,6 @@ def save_checkpoint(
         state_group.create_dataset(
             'z_minus_imag',
             data=z_minus.imag.astype(np.float32),
-            compression='gzip',
-            compression_opts=COMPRESSION_LEVEL
-        )
-
-        state_group.create_dataset(
-            'B_parallel_real',
-            data=B_parallel.real.astype(np.float32),
-            compression='gzip',
-            compression_opts=COMPRESSION_LEVEL
-        )
-        state_group.create_dataset(
-            'B_parallel_imag',
-            data=B_parallel.imag.astype(np.float32),
             compression='gzip',
             compression_opts=COMPRESSION_LEVEL
         )
@@ -324,6 +315,11 @@ def load_checkpoint(
     Note:
         Arrays are loaded as float32 and converted to JAX's default precision
         (float32 on GPU, float32/float64 depending on JAX config on CPU).
+
+        Backward compatibility: checkpoints written by older versions contain
+        /state/B_parallel_real and /state/B_parallel_imag datasets for the
+        since-removed (never-evolved) B_parallel field. These datasets are
+        silently ignored; old checkpoints load without error.
     """
     filepath = Path(filename)
 
@@ -360,12 +356,13 @@ def load_checkpoint(
         state_group = f['state']
 
         # Load raw arrays first
+        # Note: legacy checkpoints also contain B_parallel_real/B_parallel_imag
+        # datasets (the field was removed from KRMHDState because it was never
+        # evolved). They are deliberately not read here, so old files load fine.
         z_plus_real = jnp.array(state_group['z_plus_real'][:], dtype=jnp.float32)
         z_plus_imag = jnp.array(state_group['z_plus_imag'][:], dtype=jnp.float32)
         z_minus_real = jnp.array(state_group['z_minus_real'][:], dtype=jnp.float32)
         z_minus_imag = jnp.array(state_group['z_minus_imag'][:], dtype=jnp.float32)
-        B_parallel_real = jnp.array(state_group['B_parallel_real'][:], dtype=jnp.float32)
-        B_parallel_imag = jnp.array(state_group['B_parallel_imag'][:], dtype=jnp.float32)
         g_real = jnp.array(state_group['g_real'][:], dtype=jnp.float32)
         g_imag = jnp.array(state_group['g_imag'][:], dtype=jnp.float32)
 
@@ -382,11 +379,6 @@ def load_checkpoint(
                     f"z_minus shape {z_minus_real.shape} doesn't match grid "
                     f"{expected_shape}"
                 )
-            if B_parallel_real.shape != expected_shape:
-                raise ValueError(
-                    f"B_parallel shape {B_parallel_real.shape} doesn't match grid "
-                    f"{expected_shape}"
-                )
 
             # Validate Hermite moments shape
             M = int(state_group.attrs['M'])
@@ -399,14 +391,12 @@ def load_checkpoint(
         # Reconstruct complex arrays after validation
         z_plus = z_plus_real + 1j * z_plus_imag
         z_minus = z_minus_real + 1j * z_minus_imag
-        B_parallel = B_parallel_real + 1j * B_parallel_imag
         g = g_real + 1j * g_imag
 
         # Load state scalar parameters
         state = KRMHDState(
             z_plus=z_plus,
             z_minus=z_minus,
-            B_parallel=B_parallel,
             g=g,
             M=int(state_group.attrs['M']),
             beta_i=float(state_group.attrs['beta_i']),
@@ -519,7 +509,6 @@ def save_timeseries(
     times = np.array(history.times, dtype=np.float64)
     E_magnetic = np.array(history.E_magnetic, dtype=np.float64)
     E_kinetic = np.array(history.E_kinetic, dtype=np.float64)
-    E_compressive = np.array(history.E_compressive, dtype=np.float64)
     E_total = np.array(history.E_total, dtype=np.float64)
 
     with h5py.File(filename, 'w') as f:
@@ -529,8 +518,6 @@ def save_timeseries(
         f.create_dataset('E_magnetic', data=E_magnetic, compression='gzip',
                         compression_opts=COMPRESSION_LEVEL)
         f.create_dataset('E_kinetic', data=E_kinetic, compression='gzip',
-                        compression_opts=COMPRESSION_LEVEL)
-        f.create_dataset('E_compressive', data=E_compressive, compression='gzip',
                         compression_opts=COMPRESSION_LEVEL)
         f.create_dataset('E_total', data=E_total, compression='gzip',
                         compression_opts=COMPRESSION_LEVEL)
@@ -596,11 +583,13 @@ def load_timeseries(filename: str) -> Tuple[EnergyHistory, Dict[str, Any]]:
             )
 
         # Load time series data
+        # Note: legacy timeseries files also contain an E_compressive dataset
+        # (removed along with the never-evolved B_parallel field); it is
+        # deliberately not read here, so old files load fine.
         history = EnergyHistory(
             times=f['times'][:].tolist(),
             E_magnetic=f['E_magnetic'][:].tolist(),
             E_kinetic=f['E_kinetic'][:].tolist(),
-            E_compressive=f['E_compressive'][:].tolist(),
             E_total=f['E_total'][:].tolist(),
         )
 

--- a/src/krmhd/physics.py
+++ b/src/krmhd/physics.py
@@ -54,7 +54,6 @@ class KRMHDState(BaseModel):
             Co-propagating Alfvén wave packet along +B₀
         z_minus: Elsasser z⁻ = φ - A∥ in Fourier space (shape: [Nz, Ny, Nx//2+1])
             Counter-propagating Alfvén wave packet along -B₀
-        B_parallel: Parallel magnetic field δB∥ (passive) in Fourier space (shape: [Nz, Ny, Nx//2+1])
         g: Hermite moments of electron distribution (shape: [Nz, Ny, Nx//2+1, M+1])
             Expansion: g(v∥) = Σ_m g_m · ψ_m(v∥/v_th)
         M: Number of Hermite moments (typically 20-30 for converged kinetics)
@@ -75,7 +74,6 @@ class KRMHDState(BaseModel):
         >>> state = KRMHDState(
         ...     z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx//2+1), dtype=complex),
         ...     z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx//2+1), dtype=complex),
-        ...     B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx//2+1), dtype=complex),
         ...     g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx//2+1, 21), dtype=complex),
         ...     M=20,
         ...     beta_i=1.0,
@@ -89,8 +87,13 @@ class KRMHDState(BaseModel):
         The KRMHD equations in Elsasser form:
         - ∂z⁺/∂t = -∇²⊥{z⁻, z⁺} - ∇∥z⁻ + dissipation
         - ∂z⁻/∂t = -∇²⊥{z⁺, z⁻} + ∇∥z⁺ + dissipation
-        - Passive sector: B∥ is advected by φ = (z⁺ + z⁻)/2
         - Kinetic sector: g moments evolve with Landau damping and collisions
+
+        The compressive/slow-mode observables (δn_e, δB∥) are not evolved
+        fields in this formulation: they are derived diagnostics reconstructed
+        from Hermite-hierarchy runs with the kinetic parameters Λ± (thesis;
+        dne_dbpar.cu postprocessor in the original GANDALF). Reconstruction
+        is not yet implemented here.
 
         The Elsasser formulation simplifies the Alfvén wave dynamics compared
         to the coupled (φ, A∥) formulation used in earlier versions.
@@ -104,7 +107,6 @@ class KRMHDState(BaseModel):
 
     z_plus: Array = Field(description="Elsasser z+ (co-propagating wave) in Fourier space")
     z_minus: Array = Field(description="Elsasser z- (counter-propagating wave) in Fourier space")
-    B_parallel: Array = Field(description="Parallel magnetic field in Fourier space")
     g: Array = Field(description="Hermite moments of electron distribution")
     M: int = Field(ge=0, description="Number of Hermite moments (M=0: pure fluid RMHD, g has 1 slot kept zero; M>=2: kinetic with g_0..g_M)")
     beta_i: float = Field(gt=0.0, description="Ion plasma beta")
@@ -114,7 +116,7 @@ class KRMHDState(BaseModel):
     time: float = Field(ge=0.0, description="Simulation time")
     grid: SpectralGrid3D = Field(description="Spectral grid specification")
 
-    @field_validator("z_plus", "z_minus", "B_parallel")
+    @field_validator("z_plus", "z_minus")
     @classmethod
     def validate_field_shape(cls, v: Array, info) -> Array:
         """Validate that fields have correct 3D Fourier space shape."""
@@ -175,13 +177,13 @@ class KRMHDState(BaseModel):
         # Import energy calculation (defined later in this file)
         from krmhd.physics import energy
 
-        E_mag, E_kin, E_comp = energy(self)
-        E_tot = E_mag + E_kin + E_comp
+        E = energy(self)
 
         return (
             f"KRMHDState(t={self.time:.3f}, "
             f"grid={self.grid.Nx}×{self.grid.Ny}×{self.grid.Nz}, "
-            f"E_tot={E_tot:.3e}, E_mag={E_mag:.3e}, E_kin={E_kin:.3e}, "
+            f"E_tot={E['total']:.3e}, E_mag={E['magnetic']:.3e}, "
+            f"E_kin={E['kinetic']:.3e}, "
             f"M={self.M}, β_i={self.beta_i:.2f})"
         )
 
@@ -191,14 +193,14 @@ def _krmhd_state_flatten(state: KRMHDState):
     """
     Flatten KRMHDState into arrays (children) and static data (aux_data).
 
-    Arrays (children): z_plus, z_minus, B_parallel, g, grid (itself a pytree)
+    Arrays (children): z_plus, z_minus, g, grid (itself a pytree)
     Static data (aux_data): M, beta_i, v_th, nu, Lambda, time
 
     The grid field is treated as a child (pytree) rather than aux_data
     because it contains JAX arrays (kx, ky, kz, dealias_mask) and is
     registered as a pytree.
     """
-    children = (state.z_plus, state.z_minus, state.B_parallel, state.g, state.grid)
+    children = (state.z_plus, state.z_minus, state.g, state.grid)
     aux_data = (state.M, state.beta_i, state.v_th, state.nu, state.Lambda, state.time)
     return children, aux_data
 
@@ -211,11 +213,10 @@ def _krmhd_state_unflatten(aux_data, children):
     from JAX tree operations (including grid as a pytree).
     """
     M, beta_i, v_th, nu, Lambda, time = aux_data
-    z_plus, z_minus, B_parallel, g, grid = children
+    z_plus, z_minus, g, grid = children
     return KRMHDState(
         z_plus=z_plus,
         z_minus=z_minus,
-        B_parallel=B_parallel,
         g=g,
         M=M,
         beta_i=beta_i,
@@ -1243,7 +1244,7 @@ def initialize_alfven_wave(
 
     The wave is initialized with correct phase relationship:
     - phi and A_parallel in quadrature (90° phase difference)
-    - B_parallel = 0 (pure Alfvén wave has no compressibility)
+    - Pure Alfvén wave has no compressibility
 
     Args:
         grid: SpectralGrid3D defining spatial dimensions
@@ -1273,7 +1274,6 @@ def initialize_alfven_wave(
     # Initialize empty fields
     phi = jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64)
     A_parallel = jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64)
-    B_parallel = jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64)
 
     # Find indices corresponding to desired wavenumber
     # This is approximate - we pick the closest wavenumber on the grid
@@ -1296,7 +1296,6 @@ def initialize_alfven_wave(
     return KRMHDState(
         z_plus=z_plus,
         z_minus=z_minus,
-        B_parallel=B_parallel,
         g=g,
         M=M,
         beta_i=beta_i,
@@ -1411,9 +1410,6 @@ def initialize_random_spectrum(
     # Convert to Elsasser variables
     z_plus, z_minus = physical_to_elsasser(phi, A_parallel)
 
-    # Passive scalar B_parallel (initially zero, will be excited by cascade)
-    B_parallel = jnp.zeros_like(phi)
-
     # Initialize Hermite moments (equilibrium, or with small perturbations for kinetic physics)
     # Use fold_in to derive an independent seed for g, avoiding collisions with other seeds
     g_key = jax.random.fold_in(jax.random.PRNGKey(seed), 1)
@@ -1427,7 +1423,6 @@ def initialize_random_spectrum(
     return KRMHDState(
         z_plus=z_plus,
         z_minus=z_minus,
-        B_parallel=B_parallel,
         g=g,
         M=M,
         beta_i=beta_i,
@@ -1457,7 +1452,6 @@ def energy(state: KRMHDState) -> Dict[str, float]:
     Calculates energy contributions from:
     - Magnetic energy: E_mag = (1/2) ∫ |B⊥|² dx = (1/2) ∫ |∇A∥|² dx
     - Kinetic energy: E_kin = (1/2) ∫ |v⊥|² dx = (1/2) ∫ |∇φ|² dx
-    - Compressive energy: E_comp = (1/2) ∫ |δB∥|² dx
 
     All energies are computed in Fourier space using Parseval's theorem:
         ∫ |f(x)|² dx = ∫ |f̂(k)|² dk
@@ -1469,8 +1463,7 @@ def energy(state: KRMHDState) -> Dict[str, float]:
         Dictionary with energy components:
         - 'magnetic': Magnetic energy from perpendicular field
         - 'kinetic': Kinetic energy from perpendicular flow
-        - 'compressive': Compressive energy from parallel field
-        - 'total': Sum of fluid components (excludes Hermite energy)
+        - 'total': E_magnetic + E_kinetic (excludes Hermite energy)
 
     Example:
         >>> grid = SpectralGrid3D.create(Nx=64, Ny=64, Nz=64)
@@ -1482,10 +1475,15 @@ def energy(state: KRMHDState) -> Dict[str, float]:
     Physics:
         - For Alfvén waves: E_mag ≈ E_kin (equipartition)
         - For decaying turbulence: E_mag/E_kin increases (selective decay)
-        - E_comp should remain small (passive, no back-reaction)
 
         Energy should be conserved in inviscid (nu=eta=0) simulations to
         within numerical precision (~1e-10 relative error).
+
+    Note:
+        There is no compressive energy component: δB∥ is not an evolved
+        field in this formulation. The slow-mode observables (δn_e, δB∥)
+        are derived diagnostics of the Λ± Hermite hierarchies (thesis;
+        dne_dbpar.cu in the original GANDALF), not yet implemented.
     """
     grid = state.grid
 
@@ -1549,14 +1547,8 @@ def energy(state: KRMHDState) -> Dict[str, float]:
         jnp.sum(jnp.where(kx_middle, 2.0 * A_par_grad_squared, A_par_grad_squared))
     ).real
 
-    # Compressive energy: E_comp = (1/2) ∫ |δB∥|² dx
-    B_mag_squared = jnp.abs(state.B_parallel) ** 2
-    E_compressive = 0.5 * norm_factor * (
-        jnp.sum(jnp.where(kx_middle, 2.0 * B_mag_squared, B_mag_squared))
-    ).real
-
     # Total energy
-    E_total = E_magnetic + E_kinetic + E_compressive
+    E_total = E_magnetic + E_kinetic
 
     # NOTE: We're not including kinetic (Hermite moment) energy here yet
     # That would require integrating over velocity space as well
@@ -1565,7 +1557,6 @@ def energy(state: KRMHDState) -> Dict[str, float]:
     return {
         "magnetic": float(E_magnetic),
         "kinetic": float(E_kinetic),
-        "compressive": float(E_compressive),
         "total": float(E_total),
     }
 
@@ -1709,9 +1700,6 @@ def initialize_orszag_tang(
     # which are well-resolved on the grid. Dealiasing is only required AFTER
     # nonlinear operations (Poisson brackets) to prevent aliasing errors.
 
-    # Initialize parallel magnetic field (passive, set to zero for pure Alfvén mode)
-    B_parallel = jnp.zeros_like(z_plus_k)
-
     # Initialize Hermite moments (kinetic distribution)
     # g = 0 represents fluid limit: no kinetic response
     # This is appropriate for Orszag-Tang, which tests fluid nonlinear dynamics
@@ -1720,7 +1708,6 @@ def initialize_orszag_tang(
     return KRMHDState(
         z_plus=z_plus_k,
         z_minus=z_minus_k,
-        B_parallel=B_parallel,
         g=g,
         M=M,
         beta_i=beta_i,

--- a/src/krmhd/timestepping.py
+++ b/src/krmhd/timestepping.py
@@ -82,7 +82,6 @@ class KRMHDFields(NamedTuple):
     """
     z_plus: Array
     z_minus: Array
-    B_parallel: Array
     g: Array  # Shape: [Nz, Ny, Nx//2+1, M+1]
     time: float  # Python float at public API; JAX Array inside JIT context
 
@@ -92,7 +91,6 @@ def _fields_from_state(state: KRMHDState) -> KRMHDFields:
     return KRMHDFields(
         z_plus=state.z_plus,
         z_minus=state.z_minus,
-        B_parallel=state.B_parallel,
         g=state.g,
         time=state.time,
     )
@@ -107,7 +105,6 @@ def _state_from_fields(fields: KRMHDFields, state_template: KRMHDState) -> KRMHD
     return KRMHDState(
         z_plus=fields.z_plus,
         z_minus=fields.z_minus,
-        B_parallel=fields.B_parallel,
         g=fields.g,
         M=state_template.M,
         beta_i=state_template.beta_i,
@@ -169,9 +166,6 @@ def _krmhd_rhs_jit(
         Ny,
         Nx,
     )
-
-    # Passive scalar B∥ evolution (Issue #7 - not yet implemented)
-    dB_parallel_dt = jnp.zeros_like(fields.B_parallel)
 
     # Hermite moment evolution (Issue #49 - now fully implemented!)
     # **OPTIMIZATION**: For M=0 (pure fluid mode), skip all kinetic physics computation.
@@ -244,7 +238,6 @@ def _krmhd_rhs_jit(
     return KRMHDFields(
         z_plus=dz_plus_dt,
         z_minus=dz_minus_dt,
-        B_parallel=dB_parallel_dt,
         g=dg_dt,
         time=0.0,  # Not a derivative
     )
@@ -263,7 +256,6 @@ def krmhd_rhs(
 
     Currently implements:
     - Elsasser fields: z⁺, z⁻ (Alfvénic sector)
-    - B∥: Passive parallel magnetic field (Issue #7 - not yet implemented)
     - g: Hermite moments (Issues #22-24, #49 - fully implemented!)
 
     Args:
@@ -486,7 +478,6 @@ def _gandalf_step_lawson_rk4_jit(
     fields_half = KRMHDFields(
         z_plus=z_plus_half,
         z_minus=z_minus_half,
-        B_parallel=fields.B_parallel,
         g=g_stage_2,
         time=fields.time + dt / 2.0,
     )
@@ -522,7 +513,6 @@ def _gandalf_step_lawson_rk4_jit(
     fields_half_rk4 = KRMHDFields(
         z_plus=z_plus_half,
         z_minus=z_minus_half,
-        B_parallel=fields.B_parallel,
         g=g_stage_3,
         time=fields.time + dt / 2.0,
     )
@@ -535,7 +525,6 @@ def _gandalf_step_lawson_rk4_jit(
     fields_full_rk4 = KRMHDFields(
         z_plus=z_plus_new,
         z_minus=z_minus_new,
-        B_parallel=fields.B_parallel,
         g=g_stage_4,
         time=fields.time + dt,
     )
@@ -613,7 +602,6 @@ def _gandalf_step_lawson_rk4_jit(
     return KRMHDFields(
         z_plus=z_plus_new,
         z_minus=z_minus_new,
-        B_parallel=fields.B_parallel,  # TODO: Issue #7
         g=g_new,
         time=fields.time + dt,
     )
@@ -810,7 +798,6 @@ def _gandalf_step_imex222_jit(
     fields_half = KRMHDFields(
         z_plus=z_plus_half,
         z_minus=z_minus_half,
-        B_parallel=fields.B_parallel,
         g=g_1,
         time=fields.time + dt / 2.0,
     )
@@ -868,12 +855,6 @@ def _gandalf_step_imex222_jit(
     return KRMHDFields(
         z_plus=z_plus_new,
         z_minus=z_minus_new,
-        # B_parallel is passed through unchanged, matching the Lawson path
-        # byte-for-byte (see Lawson kernel end-of-body with `TODO: Issue #7`).
-        # Slow-mode evolution is a separate, pre-existing TODO tracked in
-        # https://github.com/anjor/gandalf/issues/7 ; this PR does not change
-        # its handling in either scheme.
-        B_parallel=fields.B_parallel,
         g=g_new,
         time=fields.time + dt,
     )

--- a/tests/test_balanced_elsasser_forcing.py
+++ b/tests/test_balanced_elsasser_forcing.py
@@ -23,13 +23,11 @@ def create_zero_state(grid: SpectralGrid3D, M: int = 10) -> KRMHDState:
     """Helper to create a zero-initialized KRMHDState for testing."""
     z_plus = jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=complex)
     z_minus = jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=complex)
-    B_parallel = jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=complex)
     g = jnp.zeros((M + 1, grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=complex)
 
     return KRMHDState(
         z_plus=z_plus,
         z_minus=z_minus,
-        B_parallel=B_parallel,
         g=g,
         M=M,
         beta_i=1.0,
@@ -291,14 +289,13 @@ def test_correlation_parameter_range():
 
 
 def test_forcing_preserves_other_fields():
-    """Test that forcing only affects z+ and z-, not B_parallel or g."""
+    """Test that forcing only affects z+ and z-, not g."""
     grid = SpectralGrid3D.create(Nx=32, Ny=32, Nz=32)
     state = create_zero_state(grid, M=10)
 
-    # Set non-zero values in B_parallel and g
+    # Set non-zero values in g
     state = state.model_copy(
         update=dict(
-            B_parallel=jnp.ones_like(state.B_parallel) * 0.5,
             g=jnp.ones_like(state.g) * 0.3,
         )
     )
@@ -317,9 +314,7 @@ def test_forcing_preserves_other_fields():
         max_nz=1,
     )
 
-    # B_parallel and g should be unchanged
-    assert jnp.allclose(state_forced.B_parallel, state.B_parallel), \
-        "Forcing modified B_parallel (should only affect z± fields)"
+    # g should be unchanged
     assert jnp.allclose(state_forced.g, state.g), \
         "Forcing modified Hermite moments (should only affect z± fields)"
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -130,7 +130,6 @@ class TestEnergySpectrum1D:
         state = KRMHDState(
             z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1, 11), dtype=jnp.complex64),
             M=10,
             beta_i=1.0,
@@ -203,7 +202,6 @@ class TestEnergySpectrumPerpendicular:
         state = KRMHDState(
             z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1, 11), dtype=jnp.complex64),
             M=10,
             beta_i=1.0,
@@ -298,7 +296,6 @@ class TestEnergySpectrumPerpendicularKinetic:
         state = KRMHDState(
             z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1, 11), dtype=jnp.complex64),
             M=10,
             beta_i=1.0,
@@ -384,7 +381,6 @@ class TestEnergySpectrumPerpendicularMagnetic:
         state = KRMHDState(
             z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1, 11), dtype=jnp.complex64),
             M=10,
             beta_i=1.0,
@@ -464,7 +460,6 @@ class TestAlfvenicEquipartition:
 
         state_kin = KRMHDState(
             grid=grid, z_plus=z_plus, z_minus=z_minus,
-            B_parallel=jnp.zeros_like(z_plus),
             g=jnp.zeros((10, grid.Nz, grid.Ny, grid.Nx//2+1), dtype=complex),
             M=10, beta_i=1.0, v_th=1.0, nu=0.01, Lambda=1.0, time=0.0,
         )
@@ -483,7 +478,6 @@ class TestAlfvenicEquipartition:
 
         state_mag = KRMHDState(
             grid=grid, z_plus=z_plus, z_minus=z_minus,
-            B_parallel=jnp.zeros_like(z_plus),
             g=jnp.zeros((10, grid.Nz, grid.Ny, grid.Nx//2+1), dtype=complex),
             M=10, beta_i=1.0, v_th=1.0, nu=0.01, Lambda=1.0, time=0.0,
         )
@@ -543,7 +537,6 @@ class TestEnergySpectrumParallel:
         state = KRMHDState(
             z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1, 11), dtype=jnp.complex64),
             M=10,
             beta_i=1.0,
@@ -582,7 +575,6 @@ class TestEnergySpectrum2D:
         state = KRMHDState(
             z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1, 11), dtype=jnp.complex64),
             M=10, beta_i=1.0, v_th=1.0, nu=0.01, Lambda=1.0, time=0.0, grid=grid,
         )
@@ -666,7 +658,6 @@ class TestEnergyHistory:
         assert len(history.times) == 0
         assert len(history.E_magnetic) == 0
         assert len(history.E_kinetic) == 0
-        assert len(history.E_compressive) == 0
         assert len(history.E_total) == 0
 
     def test_energy_history_append(self):
@@ -680,14 +671,12 @@ class TestEnergyHistory:
         assert len(history.times) == 1
         assert len(history.E_magnetic) == 1
         assert len(history.E_kinetic) == 1
-        assert len(history.E_compressive) == 1
         assert len(history.E_total) == 1
 
         # Values should match direct energy calculation
         energies = compute_energy(state)
         assert jnp.isclose(history.E_magnetic[0], energies['magnetic'])
         assert jnp.isclose(history.E_kinetic[0], energies['kinetic'])
-        assert jnp.isclose(history.E_compressive[0], energies['compressive'])
         assert jnp.isclose(history.E_total[0], energies['total'])
 
     def test_energy_history_multiple_appends(self):
@@ -720,7 +709,6 @@ class TestEnergyHistory:
         assert 'times' in data
         assert 'E_magnetic' in data
         assert 'E_kinetic' in data
-        assert 'E_compressive' in data
         assert 'E_total' in data
 
         assert len(data['times']) == 1
@@ -1158,13 +1146,11 @@ class TestComputeMagneticFieldComponents:
         # Create state with zero perturbations
         z_plus = jnp.zeros((32, 32, 17), dtype=complex)
         z_minus = jnp.zeros((32, 32, 17), dtype=complex)
-        B_parallel = jnp.zeros((32, 32, 17), dtype=complex)
         g = jnp.zeros((32, 32, 17, 11), dtype=complex)
 
         state = KRMHDState(
             z_plus=z_plus,
             z_minus=z_minus,
-            B_parallel=B_parallel,
             g=g,
             M=10,
             beta_i=1.0,
@@ -1213,11 +1199,10 @@ class TestFollowFieldLine:
         # Zero perturbations → straight field
         z_plus = jnp.zeros((32, 32, 17), dtype=complex)
         z_minus = jnp.zeros((32, 32, 17), dtype=complex)
-        B_parallel = jnp.zeros((32, 32, 17), dtype=complex)
         g = jnp.zeros((32, 32, 17, 11), dtype=complex)
 
         state = KRMHDState(
-            z_plus=z_plus, z_minus=z_minus, B_parallel=B_parallel, g=g,
+            z_plus=z_plus, z_minus=z_minus, g=g,
             M=10, beta_i=1.0, v_th=1.0, nu=0.01, Lambda=1.0, time=0.0, grid=grid
         )
 
@@ -1273,11 +1258,10 @@ class TestFollowFieldLine:
         # Straight field for exact solution
         z_plus = jnp.zeros((16, 16, 9), dtype=complex)
         z_minus = jnp.zeros((16, 16, 9), dtype=complex)
-        B_parallel = jnp.zeros((16, 16, 9), dtype=complex)
         g = jnp.zeros((16, 16, 9, 11), dtype=complex)
 
         state = KRMHDState(
-            z_plus=z_plus, z_minus=z_minus, B_parallel=B_parallel, g=g,
+            z_plus=z_plus, z_minus=z_minus, g=g,
             M=10, beta_i=1.0, v_th=1.0, nu=0.01, Lambda=1.0, time=0.0, grid=grid
         )
 
@@ -1342,7 +1326,6 @@ class TestHermiteFlux:
         state = KRMHDState(
             z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1, 11), dtype=jnp.complex64),
             M=10,
             beta_i=1.0,
@@ -1410,7 +1393,6 @@ class TestHermiteFlux:
         state = KRMHDState(
             z_plus=jnp.zeros((8, 16, 9), dtype=complex),
             z_minus=jnp.zeros((8, 16, 9), dtype=complex),
-            B_parallel=jnp.zeros((8, 16, 9), dtype=complex),
             g=g,
             M=5,
             beta_i=1.0,
@@ -1475,7 +1457,6 @@ class TestHermiteMomentEnergy:
         state = KRMHDState(
             z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1, 11), dtype=jnp.complex64),
             M=10,
             beta_i=1.0,
@@ -1513,7 +1494,6 @@ class TestHermiteMomentEnergy:
         state = KRMHDState(
             z_plus=state.z_plus,
             z_minus=state.z_minus,
-            B_parallel=state.B_parallel,
             g=g,
             M=15,
             beta_i=state.beta_i,
@@ -1595,7 +1575,6 @@ class TestPhaseMixingEnergy:
         state = KRMHDState(
             z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1, 11), dtype=jnp.complex64),
             M=10,
             beta_i=1.0,
@@ -1691,7 +1670,6 @@ class TestTurbulenceDiagnostics:
         state = KRMHDState(
             z_plus=jnp.zeros((8, 16, 9), dtype=complex),
             z_minus=jnp.zeros((8, 16, 9), dtype=complex),
-            B_parallel=jnp.zeros((8, 16, 9), dtype=complex),
             g=jnp.zeros((10, 8, 16, 9), dtype=complex),
             M=10,
             beta_i=1.0,
@@ -1754,7 +1732,7 @@ class TestTurbulenceDiagnostics:
 
         # Compute energy via physics module (returns dict)
         energy_dict = energy(state)
-        E_total = energy_dict["magnetic"] + energy_dict["kinetic"] + energy_dict["compressive"]
+        E_total = energy_dict["magnetic"] + energy_dict["kinetic"]
 
         # Should match (within numerical precision)
         rel_error = jnp.abs(diag.energy_total - E_total) / (E_total + 1e-30)
@@ -1929,7 +1907,6 @@ class TestComputeDissipationRate:
         state = KRMHDState(
             z_plus=jnp.zeros((8, 16, 9), dtype=complex),
             z_minus=jnp.zeros((8, 16, 9), dtype=complex),
-            B_parallel=jnp.zeros((8, 16, 9), dtype=complex),
             g=jnp.zeros((8, 16, 9, 11), dtype=complex),
             M=10, beta_i=1.0, v_th=1.0, nu=0.01, Lambda=1.0,
             time=0.0, grid=grid,

--- a/tests/test_forcing.py
+++ b/tests/test_forcing.py
@@ -15,7 +15,6 @@ from krmhd import (
     gaussian_white_noise_fourier,
     force_alfven_modes,
     force_alfven_modes_specific,
-    force_slow_modes,
     compute_energy_injection_rate,
     gandalf_step,
     energy,
@@ -400,61 +399,6 @@ class TestAlfvenForcing:
 
         # Hermite moments should be unchanged
         assert jnp.allclose(state_forced.g, g_old)
-
-
-class TestSlowModeForcing:
-    """Test slow mode forcing (δB∥)."""
-
-    def test_B_parallel_increases(self):
-        """Slow mode forcing should increase |B∥|."""
-        grid = SpectralGrid3D.create(Nx=32, Ny=32, Nz=16)
-        state = initialize_alfven_wave(grid, M=10, kz_mode=1, amplitude=0.1)
-        key = jax.random.PRNGKey(42)
-
-        B_parallel_magnitude_old = jnp.sum(jnp.abs(state.B_parallel)**2)
-
-        state_forced, key = force_slow_modes(
-            state, amplitude=0.5, n_min=1, n_max=2, dt=0.01, key=key
-        )
-
-        B_parallel_magnitude_new = jnp.sum(jnp.abs(state_forced.B_parallel)**2)
-
-        # B∥ magnitude should increase
-        assert B_parallel_magnitude_new > B_parallel_magnitude_old
-
-    def test_independent_from_alfven_forcing(self):
-        """Slow mode forcing should not affect Elsasser variables."""
-        grid = SpectralGrid3D.create(Nx=32, Ny=32, Nz=16)
-        state = initialize_alfven_wave(grid, M=10, kz_mode=1, amplitude=0.1)
-        key = jax.random.PRNGKey(42)
-
-        z_plus_old = state.z_plus.copy()
-        z_minus_old = state.z_minus.copy()
-
-        state_forced, key = force_slow_modes(
-            state, amplitude=0.1, n_min=1, n_max=2, dt=0.01, key=key
-        )
-
-        # Elsasser variables should be unchanged
-        assert jnp.allclose(state_forced.z_plus, z_plus_old)
-        assert jnp.allclose(state_forced.z_minus, z_minus_old)
-
-    def test_slow_mode_energy_injection(self):
-        """Slow mode forcing should inject energy."""
-        grid = SpectralGrid3D.create(Nx=32, Ny=32, Nz=16)
-        state = initialize_alfven_wave(grid, M=10, kz_mode=1, amplitude=0.01)
-        key = jax.random.PRNGKey(42)
-
-        E_before = energy(state)["total"]
-
-        state_forced, key = force_slow_modes(
-            state, amplitude=0.5, n_min=1, n_max=2, dt=0.01, key=key
-        )
-
-        E_after = energy(state_forced)["total"]
-
-        # Energy should increase
-        assert E_after > E_before
 
 
 class TestEnergyInjection:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -96,7 +96,6 @@ def test_checkpoint_roundtrip(state, tmpdir):
     # Check state fields (allow small numerical error from float32 storage)
     assert np.allclose(loaded_state.z_plus, state.z_plus, rtol=1e-6, atol=1e-7)
     assert np.allclose(loaded_state.z_minus, state.z_minus, rtol=1e-6, atol=1e-7)
-    assert np.allclose(loaded_state.B_parallel, state.B_parallel, rtol=1e-6, atol=1e-7)
     assert np.allclose(loaded_state.g, state.g, rtol=1e-6, atol=1e-7)
 
     # Check state parameters
@@ -208,10 +207,13 @@ def test_checkpoint_complex_dtype(state, tmpdir):
         assert 'z_plus_imag' in f['state']
         assert 'z_minus_real' in f['state']
         assert 'z_minus_imag' in f['state']
-        assert 'B_parallel_real' in f['state']
-        assert 'B_parallel_imag' in f['state']
         assert 'g_real' in f['state']
         assert 'g_imag' in f['state']
+
+        # B_parallel was removed (never evolved); new checkpoints must not
+        # contain its datasets
+        assert 'B_parallel_real' not in f['state']
+        assert 'B_parallel_imag' not in f['state']
 
         # Check dtypes (should be float32)
         assert f['state']['z_plus_real'].dtype == np.float32
@@ -221,7 +223,6 @@ def test_checkpoint_complex_dtype(state, tmpdir):
     loaded_state, _, _ = load_checkpoint(str(filename))
     assert jnp.iscomplexobj(loaded_state.z_plus)
     assert jnp.iscomplexobj(loaded_state.z_minus)
-    assert jnp.iscomplexobj(loaded_state.B_parallel)
     assert jnp.iscomplexobj(loaded_state.g)
 
 
@@ -427,7 +428,6 @@ def test_timeseries_roundtrip(energy_history, tmpdir):
     assert np.allclose(loaded_history.times, energy_history.times)
     assert np.allclose(loaded_history.E_magnetic, energy_history.E_magnetic)
     assert np.allclose(loaded_history.E_kinetic, energy_history.E_kinetic)
-    assert np.allclose(loaded_history.E_compressive, energy_history.E_compressive)
     assert np.allclose(loaded_history.E_total, energy_history.E_total)
 
     # Check metadata
@@ -527,7 +527,6 @@ def test_timeseries_dtype(energy_history, tmpdir):
         assert f['times'].dtype == np.float64
         assert f['E_magnetic'].dtype == np.float64
         assert f['E_kinetic'].dtype == np.float64
-        assert f['E_compressive'].dtype == np.float64
         assert f['E_total'].dtype == np.float64
 
 
@@ -622,7 +621,6 @@ def test_checkpoint_with_zero_fields(grid, tmpdir):
     state_zero = KRMHDState(
         z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=complex),
         z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=complex),
-        B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=complex),
         g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1, 11), dtype=complex),
         M=10,
         beta_i=1.0,
@@ -640,8 +638,88 @@ def test_checkpoint_with_zero_fields(grid, tmpdir):
 
     assert np.allclose(loaded_state.z_plus, 0.0)
     assert np.allclose(loaded_state.z_minus, 0.0)
-    assert np.allclose(loaded_state.B_parallel, 0.0)
     assert np.allclose(loaded_state.g, 0.0)
+
+
+def test_checkpoint_legacy_b_parallel_datasets_ignored(tmpdir):
+    """Old-format checkpoints containing B_parallel datasets must still load.
+
+    Checkpoints written before B_parallel was removed (it was stored but
+    never evolved) contain /state/B_parallel_real and /state/B_parallel_imag.
+    load_checkpoint must silently ignore them - no KeyError, no shape errors -
+    and reconstruct the state from the remaining fields.
+
+    The file is built by hand with h5py, replicating the OLD writer's layout
+    exactly (dataset names, attribute names, float32 storage, gzip level 4).
+    """
+    from datetime import datetime
+
+    Nx, Ny, Nz = 8, 8, 4
+    M = 2
+    rng = np.random.default_rng(7)
+
+    def rand_complex(shape):
+        return (rng.standard_normal(shape) + 1j * rng.standard_normal(shape)).astype(np.complex64)
+
+    field_shape = (Nz, Ny, Nx // 2 + 1)
+    z_plus = rand_complex(field_shape)
+    z_minus = rand_complex(field_shape)
+    B_parallel = rand_complex(field_shape)  # legacy field, should be ignored
+    g = rand_complex((Nz, Ny, Nx // 2 + 1, M + 1))
+
+    filename = tmpdir / "legacy_checkpoint.h5"
+    with h5py.File(filename, 'w') as f:
+        state_group = f.create_group('state')
+        grid_group = f.create_group('grid')
+        meta_group = f.create_group('metadata')
+
+        # Old writer stored each complex field as float32 real/imag pairs
+        # with gzip level-4 compression (see io.py history).
+        for name, arr in [
+            ('z_plus', z_plus),
+            ('z_minus', z_minus),
+            ('B_parallel', B_parallel),  # extra legacy datasets
+            ('g', g),
+        ]:
+            state_group.create_dataset(
+                f'{name}_real', data=arr.real.astype(np.float32),
+                compression='gzip', compression_opts=4,
+            )
+            state_group.create_dataset(
+                f'{name}_imag', data=arr.imag.astype(np.float32),
+                compression='gzip', compression_opts=4,
+            )
+
+        state_group.attrs['M'] = M
+        state_group.attrs['beta_i'] = 1.0
+        state_group.attrs['v_th'] = 1.0
+        state_group.attrs['nu'] = 0.01
+        state_group.attrs['Lambda'] = 1.0
+        state_group.attrs['time'] = 3.5
+
+        grid_group.attrs['Nx'] = Nx
+        grid_group.attrs['Ny'] = Ny
+        grid_group.attrs['Nz'] = Nz
+        grid_group.attrs['Lx'] = 1.0
+        grid_group.attrs['Ly'] = 1.0
+        grid_group.attrs['Lz'] = 1.0
+
+        meta_group.attrs['version'] = IO_FORMAT_VERSION
+        meta_group.attrs['timestamp'] = datetime.now().isoformat()
+
+    # Must load without KeyError despite the extra B_parallel datasets
+    loaded_state, loaded_grid, metadata = load_checkpoint(str(filename))
+
+    assert loaded_grid.Nx == Nx
+    assert loaded_grid.Ny == Ny
+    assert loaded_grid.Nz == Nz
+    assert loaded_state.M == M
+    assert np.isclose(loaded_state.time, 3.5)
+    assert np.allclose(loaded_state.z_plus, z_plus, rtol=1e-6, atol=1e-7)
+    assert np.allclose(loaded_state.z_minus, z_minus, rtol=1e-6, atol=1e-7)
+    assert np.allclose(loaded_state.g, g, rtol=1e-6, atol=1e-7)
+    # The removed field must not resurface on the loaded state
+    assert not hasattr(loaded_state, 'B_parallel')
 
 
 def test_checkpoint_disable_validation(state, tmpdir):

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -613,7 +613,6 @@ class TestKRMHDState:
         state = KRMHDState(
             z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1, M + 1), dtype=jnp.complex64),
             M=M,
             beta_i=1.0,
@@ -627,7 +626,6 @@ class TestKRMHDState:
         # Check stored Elsasser variable shapes
         assert state.z_plus.shape == (grid.Nz, grid.Ny, grid.Nx // 2 + 1)
         assert state.z_minus.shape == (grid.Nz, grid.Ny, grid.Nx // 2 + 1)
-        assert state.B_parallel.shape == (grid.Nz, grid.Ny, grid.Nx // 2 + 1)
         assert state.g.shape == (grid.Nz, grid.Ny, grid.Nx // 2 + 1, M + 1)
 
         # Check computed property shapes (phi, A_parallel derived from Elsasser)
@@ -653,7 +651,6 @@ class TestKRMHDState:
             KRMHDState(
                 z_plus=jnp.zeros((grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),  # 2D instead of 3D
                 z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
-                B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
                 g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1, 11), dtype=jnp.complex64),
                 M=10,
                 beta_i=1.0,
@@ -763,9 +760,6 @@ class TestKRMHDState:
         assert jnp.any(state.phi != 0.0), "phi should have wave mode"
         assert jnp.any(state.A_parallel != 0.0), "A_parallel should have wave mode"
 
-        # Check B_parallel is zero (pure Alfvén wave)
-        assert jnp.all(state.B_parallel == 0.0), "B_parallel should be zero for Alfvén wave"
-
         # Check that only one mode is excited (approximately)
         n_nonzero_phi = jnp.sum(jnp.abs(state.phi) > 1e-10)
         n_nonzero_A = jnp.sum(jnp.abs(state.A_parallel) > 1e-10)
@@ -803,9 +797,6 @@ class TestKRMHDState:
         # Check k=0 mode is zero
         assert state.phi[0, 0, 0] == 0.0, "k=0 mode should be zero"
         assert state.A_parallel[0, 0, 0] == 0.0, "k=0 mode should be zero"
-
-        # Check B_parallel is initially zero
-        assert jnp.all(state.B_parallel == 0.0), "B_parallel should start at zero"
 
         # Check Hermite moments are equilibrium
         assert jnp.all(state.g == 0.0), "Hermite moments should be equilibrium"
@@ -868,26 +859,21 @@ class TestKRMHDState:
         # Check structure
         assert "magnetic" in E
         assert "kinetic" in E
-        assert "compressive" in E
         assert "total" in E
 
         # Check all positive
         assert E["magnetic"] >= 0.0
         assert E["kinetic"] >= 0.0
-        assert E["compressive"] >= 0.0
         assert E["total"] >= 0.0
 
         # Check total = sum
         assert jnp.isclose(
-            E["total"], E["magnetic"] + E["kinetic"] + E["compressive"]
+            E["total"], E["magnetic"] + E["kinetic"]
         ), "Total energy should equal sum of components"
 
         # For Alfvén wave, expect equipartition E_mag ≈ E_kin
         ratio = E["magnetic"] / (E["kinetic"] + 1e-20)
         assert 0.8 < ratio < 1.2, f"Alfvén wave should have E_mag ≈ E_kin, got ratio {ratio}"
-
-        # Compressive energy should be zero (no B_parallel)
-        assert E["compressive"] == 0.0, "Alfvén wave should have zero compressive energy"
 
     def test_energy_random_spectrum(self):
         """Test energy calculation for random spectrum."""
@@ -914,7 +900,7 @@ class TestKRMHDState:
 
         # Check total = sum
         assert jnp.isclose(
-            E["total"], E["magnetic"] + E["kinetic"] + E["compressive"]
+            E["total"], E["magnetic"] + E["kinetic"]
         ), "Total energy should equal sum of components"
 
         # For random initialization, energies should be of similar order
@@ -957,7 +943,6 @@ class TestKRMHDState:
         state = KRMHDState(
             z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1, M + 1), dtype=jnp.complex64),
             M=M,
             beta_i=1.0,
@@ -972,7 +957,6 @@ class TestKRMHDState:
 
         assert E["magnetic"] == 0.0
         assert E["kinetic"] == 0.0
-        assert E["compressive"] == 0.0
         assert E["total"] == 0.0
 
     def test_energy_parseval_validation(self):
@@ -1053,9 +1037,6 @@ class TestKRMHDState:
         assert jnp.isclose(ratio, 1.0, rtol=0.05), \
             f"Alfvén wave equipartition: E_mag/E_kin = {ratio}, expected ≈ 1.0"
 
-        # Compressive energy should be exactly zero
-        assert E["compressive"] == 0.0, "Pure Alfvén wave should have no compressive energy"
-
     def test_hermite_dtype_validation(self):
         """Test that Hermite moments must be complex."""
         from krmhd.physics import KRMHDState
@@ -1068,7 +1049,6 @@ class TestKRMHDState:
             KRMHDState(
                 z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
                 z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
-                B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
                 g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1, M + 1), dtype=jnp.float32),  # Real!
                 M=M,
                 beta_i=1.0,
@@ -1113,10 +1093,6 @@ class TestKRMHDState:
         # Same for A_parallel
         A_real = rfftn_inverse(state.A_parallel, grid.Nz, grid.Ny, grid.Nx)
         assert jnp.all(jnp.isreal(A_real)), "A_parallel in real space should be real-valued"
-
-        # Same for B_parallel
-        B_real = rfftn_inverse(state.B_parallel, grid.Nz, grid.Ny, grid.Nx)
-        assert jnp.all(jnp.isreal(B_real)), "B_parallel in real space should be real-valued"
 
     def test_reality_condition_random_spectrum(self):
         """Test that random spectrum initialization satisfies reality condition."""
@@ -2291,12 +2267,12 @@ class TestKRMHDStatePytree:
         from krmhd.physics import _krmhd_state_flatten, _krmhd_state_unflatten
         children, aux_data = _krmhd_state_flatten(state)
 
-        # Check children are arrays or pytrees (5 fields: z_plus, z_minus, B_parallel, g, grid)
-        assert len(children) == 5
-        # First 4 should be arrays
-        assert all(isinstance(c, jax.Array) for c in children[:4])
+        # Check children are arrays or pytrees (4 fields: z_plus, z_minus, g, grid)
+        assert len(children) == 4
+        # First 3 should be arrays
+        assert all(isinstance(c, jax.Array) for c in children[:3])
         # Last one is grid (also a pytree)
-        assert isinstance(children[4], SpectralGrid3D)
+        assert isinstance(children[3], SpectralGrid3D)
 
         # Check aux_data contains static fields
         M, beta_i, v_th, nu, Lambda, time = aux_data
@@ -2441,7 +2417,6 @@ class TestKRMHDStatePytree:
         state = KRMHDState(
             z_plus=jnp.zeros((32, 32, 17), dtype=complex),
             z_minus=jnp.zeros((32, 32, 17), dtype=complex),
-            B_parallel=jnp.zeros((32, 32, 17), dtype=complex),
             g=jnp.zeros((32, 32, 17, 6), dtype=complex),
             M=5,
             beta_i=1.0,
@@ -2458,7 +2433,6 @@ class TestKRMHDStatePytree:
             KRMHDState(
                 z_plus=jnp.zeros((32, 32, 17), dtype=complex),
                 z_minus=jnp.zeros((32, 32, 17), dtype=complex),
-                B_parallel=jnp.zeros((32, 32, 17), dtype=complex),
                 g=jnp.zeros((32, 32, 17, 6), dtype=complex),
                 M=-1,  # Invalid: must be >= 0
                 beta_i=1.0,

--- a/tests/test_timestepping.py
+++ b/tests/test_timestepping.py
@@ -41,7 +41,6 @@ class TestKRMHDRHS:
         state = KRMHDState(
             z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1, 21), dtype=jnp.complex64),
             M=20,
             beta_i=1.0,
@@ -58,7 +57,6 @@ class TestKRMHDRHS:
         # All derivatives should be zero
         assert jnp.allclose(rhs.z_plus, 0.0, atol=1e-10)
         assert jnp.allclose(rhs.z_minus, 0.0, atol=1e-10)
-        assert jnp.allclose(rhs.B_parallel, 0.0, atol=1e-10)
         assert jnp.allclose(rhs.g, 0.0, atol=1e-10)
 
     def test_rhs_shape_preservation(self):
@@ -74,7 +72,6 @@ class TestKRMHDRHS:
                    1j * jax.random.normal(keys[0], (grid.Nz, grid.Ny, grid.Nx // 2 + 1)),
             z_minus=jax.random.normal(keys[1], (grid.Nz, grid.Ny, grid.Nx // 2 + 1)) +
                     1j * jax.random.normal(keys[1], (grid.Nz, grid.Ny, grid.Nx // 2 + 1)),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1, 21), dtype=jnp.complex64),
             M=20,
             beta_i=1.0,
@@ -91,7 +88,6 @@ class TestKRMHDRHS:
         # Check shapes
         assert rhs.z_plus.shape == state.z_plus.shape
         assert rhs.z_minus.shape == state.z_minus.shape
-        assert rhs.B_parallel.shape == state.B_parallel.shape
         assert rhs.g.shape == state.g.shape
 
     def test_rhs_nonzero_output(self):
@@ -119,7 +115,6 @@ class TestGandalfStep:
         state = KRMHDState(
             z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1, 21), dtype=jnp.complex64),
             M=20,
             beta_i=1.0,
@@ -137,7 +132,6 @@ class TestGandalfStep:
         # Fields should remain zero
         assert jnp.allclose(new_state.z_plus, 0.0, atol=1e-10)
         assert jnp.allclose(new_state.z_minus, 0.0, atol=1e-10)
-        assert jnp.allclose(new_state.B_parallel, 0.0, atol=1e-10)
         assert jnp.allclose(new_state.g, 0.0, atol=1e-10)
 
         # Time should advance
@@ -155,7 +149,6 @@ class TestGandalfStep:
                    1j * jax.random.normal(keys[0], (grid.Nz, grid.Ny, grid.Nx // 2 + 1)),
             z_minus=jax.random.normal(keys[1], (grid.Nz, grid.Ny, grid.Nx // 2 + 1)) +
                     1j * jax.random.normal(keys[1], (grid.Nz, grid.Ny, grid.Nx // 2 + 1)),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1, 21), dtype=jnp.complex64),
             M=20,
             beta_i=1.0,
@@ -172,7 +165,6 @@ class TestGandalfStep:
         # Check shapes
         assert new_state.z_plus.shape == state.z_plus.shape
         assert new_state.z_minus.shape == state.z_minus.shape
-        assert new_state.B_parallel.shape == state.B_parallel.shape
         assert new_state.g.shape == state.g.shape
 
     def test_gandalf_time_increment(self):
@@ -273,7 +265,6 @@ class TestCFLCalculator:
         state = KRMHDState(
             z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1, 21), dtype=jnp.complex64),
             M=20,
             beta_i=1.0,
@@ -975,7 +966,6 @@ class TestHyperdissipationDegenerateCases:
         state = KRMHDState(
             z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx//2+1), dtype=jnp.complex64),
             z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx//2+1), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx//2+1), dtype=jnp.complex64),
             g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx//2+1, M+1), dtype=jnp.complex64),
             M=M,
             beta_i=1.0,
@@ -1005,7 +995,6 @@ class TestHyperdissipationDegenerateCases:
         state = KRMHDState(
             z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx//2+1), dtype=jnp.complex64),
             z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx//2+1), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx//2+1), dtype=jnp.complex64),
             g=jnp.zeros((grid.Nz, grid.Ny, grid.Nx//2+1, M+1), dtype=jnp.complex64),
             M=M,
             beta_i=1.0,
@@ -1094,7 +1083,6 @@ class TestHyperdissipationDegenerateCases:
         state = KRMHDState(
             z_plus=z_plus,
             z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx//2+1), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx//2+1), dtype=jnp.complex64),
             g=g,
             M=M,
             beta_i=1.0,
@@ -1285,14 +1273,12 @@ class TestHermiteIntegratingFactor:
         # Initialize with zero z± (no nonlinear terms) and small g perturbation
         z_plus = jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64)
         z_minus = jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64)
-        B_parallel = jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64)
 
         g = initialize_hermite_moments(grid, M, perturbation_amplitude=1e-3, seed=42)
 
         state = KRMHDState(
             z_plus=z_plus,
             z_minus=z_minus,
-            B_parallel=B_parallel,
             g=g,
             M=M,
             beta_i=1.0,
@@ -1337,11 +1323,10 @@ class TestHermiteIntegratingFactor:
 
         z_plus = jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64)
         z_minus = jnp.zeros_like(z_plus)
-        B_parallel = jnp.zeros_like(z_plus)
         g = initialize_hermite_moments(grid, M, perturbation_amplitude=1e-4, seed=123)
 
         state = KRMHDState(
-            z_plus=z_plus, z_minus=z_minus, B_parallel=B_parallel, g=g,
+            z_plus=z_plus, z_minus=z_minus, g=g,
             M=M, beta_i=beta_i, v_th=1.0, nu=0.0, Lambda=1.0,
             time=0.0, grid=grid,
         )
@@ -1370,7 +1355,6 @@ class TestHermiteIntegratingFactor:
         state = KRMHDState(
             z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             g=initialize_hermite_moments(grid, M, perturbation_amplitude=1e-3, seed=7),
             M=M,
             beta_i=1.0,
@@ -1411,7 +1395,6 @@ class TestHermiteIntegratingFactor:
         state = KRMHDState(
             z_plus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             z_minus=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             g=g,
             M=M,
             beta_i=1.0,
@@ -1452,7 +1435,6 @@ class TestHermiteIntegratingFactor:
         state = KRMHDState(
             z_plus=phi_fourier,
             z_minus=phi_fourier,
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, grid.Nx // 2 + 1), dtype=jnp.complex64),
             g=g,
             M=M,
             beta_i=1.0,
@@ -1497,7 +1479,6 @@ class TestHermiteIntegratingFactor:
         state = KRMHDState(
             z_plus=phi,
             z_minus=phi,
-            B_parallel=jnp.zeros_like(phi),
             g=g,
             M=M,
             beta_i=1.0,
@@ -1618,7 +1599,6 @@ class TestIMEX222:
         state = KRMHDState(
             z_plus=z_plus,
             z_minus=z_minus,
-            B_parallel=jnp.zeros((Nz, Ny, Nxh), dtype=jnp.complex64),
             g=g,
             M=M,
             beta_i=beta_i,
@@ -1714,7 +1694,6 @@ class TestIMEX222:
         state = KRMHDState(
             z_plus=jnp.zeros((Nz, Ny, Nx // 2 + 1), dtype=jnp.complex64),
             z_minus=jnp.zeros((Nz, Ny, Nx // 2 + 1), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((Nz, Ny, Nx // 2 + 1), dtype=jnp.complex64),
             g=g,
             M=M,
             beta_i=1.0,
@@ -1778,7 +1757,6 @@ class TestIMEX222:
         state = KRMHDState(
             z_plus=jnp.zeros((Nz, Ny, Nxh), dtype=jnp.complex64),
             z_minus=jnp.zeros((Nz, Ny, Nxh), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((Nz, Ny, Nxh), dtype=jnp.complex64),
             g=g,
             M=M,
             beta_i=1.0,
@@ -1855,7 +1833,6 @@ class TestIMEX222:
         state = KRMHDState(
             z_plus=z_plus,
             z_minus=z_minus,
-            B_parallel=jnp.zeros((grid.Nz, grid.Ny, Nxh), dtype=jnp.complex64),
             g=g,
             M=M,
             beta_i=1.0,
@@ -1895,28 +1872,6 @@ class TestIMEX222:
         diff_minus = float(jnp.max(jnp.abs(state_l.z_minus - state_i.z_minus)))
         assert diff_plus < 5e-4, f"z_plus parity broken at nu=2.5: {diff_plus}"
         assert diff_minus < 5e-4, f"z_minus parity broken at nu=2.5: {diff_minus}"
-
-    def test_imex222_bparallel_parity_with_lawson(self):
-        """B_parallel is a passive-slot pass-through in both schemes today
-        (Issue #7). Verify both paths leave it bit-identical so a future
-        slow-mode evolution lands in both schemes at once, not silently one
-        at a time."""
-        state0 = self._make_random_state(M=3, nu=0.0, z_amp=0.02, g_amp=0.01)
-        # Seed B_parallel with a nonzero pattern so pass-through is observable.
-        key = jax.random.PRNGKey(99)
-        kr, ki = jax.random.split(key)
-        Bp_shape = state0.B_parallel.shape
-        Bp = (0.05 * (jax.random.normal(kr, Bp_shape)
-                     + 1j * jax.random.normal(ki, Bp_shape))).astype(jnp.complex64)
-        state0 = state0.model_copy(update={"B_parallel": Bp})
-
-        state_l = gandalf_step(state0, dt=0.01, eta=0.01, v_A=1.0,
-                               nu=0.0, scheme="lawson_rk4")
-        state_i = gandalf_step(state0, dt=0.01, eta=0.01, v_A=1.0,
-                               nu=0.0, scheme="imex_rk222")
-        # Both paths pass fields.B_parallel through unchanged.
-        assert jnp.array_equal(state_l.B_parallel, state0.B_parallel)
-        assert jnp.array_equal(state_i.B_parallel, state0.B_parallel)
 
     def test_imex222_adaptive_dt_rebuilds_operator(self):
         """Changing dt between calls must trigger a fresh L/LU factorization.
@@ -1962,7 +1917,6 @@ class TestIMEX222:
         state = KRMHDState(
             z_plus=jnp.zeros((Nz, Ny, Nxh), dtype=jnp.complex64),
             z_minus=jnp.zeros((Nz, Ny, Nxh), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((Nz, Ny, Nxh), dtype=jnp.complex64),
             g=g,
             M=M,
             beta_i=beta_i,
@@ -2031,7 +1985,6 @@ class TestIMEX222:
         state = KRMHDState(
             z_plus=jnp.zeros((Nz, Ny, Nxh), dtype=jnp.complex64),
             z_minus=jnp.zeros((Nz, Ny, Nxh), dtype=jnp.complex64),
-            B_parallel=jnp.zeros((Nz, Ny, Nxh), dtype=jnp.complex64),
             g=g,
             M=M,
             beta_i=beta_i,


### PR DESCRIPTION
## Summary

Removes the dead `KRMHDState.B_parallel` field, the `force_slow_modes` forcing function, and the `E_compressive` energy component (audit finding F3; removal approved by the repo owner).

## Rationale

`B_parallel` was stored, checkpointed, forced by `force_slow_modes`, and reported as `E_compressive` by `physics.energy()` — but it was **never evolved**:

- `_krmhd_rhs_jit` hard-zeroed `dB_parallel_dt` ("TODO: Issue #7"), and both stepper kernels (`lawson_rk4`, `imex_rk222`) passed the field through unchanged.
- Anyone calling `force_slow_modes` got a physicsless random walk: energy injected into a field with no advection, no parallel dynamics, and no dissipation — unbounded accumulation, zero dynamics.
- `E_compressive` was therefore misleading: it reported "compressive energy" for a quantity with no physical evolution.

In the thesis formulation the physical slow-mode fields (δn_e, δB∥) are **derived diagnostics**, reconstructed from Hermite-hierarchy runs with the two kinetic parameters Λ⁺ and Λ⁻ (see `dne_dbpar.cu` in the original GANDALF repo — a postprocessor combining two runs), not independently evolved fields. Removing the dead field makes the code honest about what it evolves; a future Λ± reconstruction can add the derived diagnostics properly.

## Issue #7

Issue #7 ("Step 7: Passive Scalar Evolution") is closed-as-completed but the passive scalar evolution was **never actually implemented** — the RHS returned zeros the whole time. This PR resolves that inconsistency by removal: the field is gone rather than pretending to be evolved. Refs #7.

## Checkpoint compatibility guarantee

**Old checkpoint and timeseries files still load.**

- `load_checkpoint` silently ignores the legacy `/state/B_parallel_real` / `/state/B_parallel_imag` datasets present in old files (and does not KeyError on new files that lack them).
- `load_timeseries` likewise ignores the legacy `/E_compressive` dataset.
- `IO_FORMAT_VERSION` is intentionally unchanged (old files remain fully readable); the format change is documented in the `io.py` module docstring.
- New test `test_checkpoint_legacy_b_parallel_datasets_ignored` builds an old-format HDF5 file by hand — replicating the old writer's exact dataset/attribute layout plus the extra `B_parallel_real/imag` datasets — and verifies it loads correctly.

## API changes (breaking)

- `KRMHDState` no longer has a `B_parallel` field (constructor arg removed everywhere; pytree now has 4 children: `z_plus`, `z_minus`, `g`, `grid`).
- `krmhd.force_slow_modes` deleted (it was the only way to put energy into the dead field).
- `physics.energy()` returns `{'magnetic', 'kinetic', 'total'}` — the `'compressive'` key is gone and `total = magnetic + kinetic`.
- `EnergyHistory` no longer tracks `E_compressive`; energy plots drop the Compressive series; `save_timeseries` no longer writes `/E_compressive`.
- Field-line following (`compute_magnetic_field_components`) now uses Bz = B₀ exactly (δB∥ ≡ 0, consistent with RMHD ordering where δB∥/B₀ = O(ε)); the docstring notes δB∥ is a derived diagnostic of the Λ± hierarchies, not yet implemented.
- Drive-by fix: `KRMHDState.__repr__` previously did `E_mag, E_kin, E_comp = energy(self)` on a 4-key dict (a latent ValueError on any `repr(state)`); it now reads the dict properly.

## Test status

`uv run pytest tests/ -q --ignore=tests/test_modal.py --ignore=tests/test_performance.py`:

**610 passed, 1 skipped, 12 failed (3m01s) — all 12 failures are pre-existing on main**, verified by rerunning the same tests on an unmodified main checkout (identical failure set and identical error messages):

- `tests/test_io.py` (4): `test_turbulence_diagnostics_{roundtrip,metadata_preservation,empty_list,compression}` — TypeError / IndexError / compression-size assertion in the `TurbulenceDiagnostics` I/O path (untouched by this PR).
- `tests/test_physics.py::TestKRMHDState::test_energy_parseval_validation` (1) — order-dependent: passes in isolation, fails when the full class runs, with a factor-16 magnetic-energy mismatch (`auto=3.91e-05` vs `manual=2.44e-06`); identical behavior on main.
- `tests/test_run_simulation.py` (7) — all cascade from a pre-existing `UnboundLocalError: cannot access local variable 'np'` at `scripts/run_simulation.py:306` on main.

New test `test_checkpoint_legacy_b_parallel_datasets_ignored` passes. Smoke checks: `uv run python -c "import krmhd"` OK; `examples/benchmarks/forcing_minimal.py` runs to completion; both integrator schemes (`imex_rk222`, `lawson_rk4`) step correctly; checkpoint and timeseries save/load roundtrips verified.

## Merge order

**MERGE LAST** — this PR touches the same files as the concurrently-open physics/timestepping fix PRs and should be rebased after they land.
