### PR TITLE
Fix pre-existing test failures: np shadowing, turbulence-diagnostics IO, Parseval normalization

### DIFF
--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -98,7 +98,6 @@ def run_simulation(
         key = jr.PRNGKey(config.forcing.seed or 42)
         if verbose:
             # Show both physical wavenumbers and mode numbers for clarity
-            import numpy as np
             L_min = min(grid.Lx, grid.Ly, grid.Lz)
             n_min = int(np.round(config.forcing.k_min * L_min / (2 * np.pi)))
             n_max = int(np.round(config.forcing.k_max * L_min / (2 * np.pi)))
@@ -182,7 +181,6 @@ def run_simulation(
         if config.forcing.enabled:
             # Convert physical wavenumbers to integer mode numbers (Issue #97)
             # k = 2πn/L_min, so n = k*L_min/(2π)
-            import numpy as np
             L_min = min(grid.Lx, grid.Ly, grid.Lz)
             n_min = int(np.round(config.forcing.k_min * L_min / (2 * np.pi)))
             n_max = int(np.round(config.forcing.k_max * L_min / (2 * np.pi)))

--- a/src/krmhd/io.py
+++ b/src/krmhd/io.py
@@ -665,8 +665,9 @@ def save_turbulence_diagnostics(
         f.attrs['format_version'] = IO_FORMAT_VERSION
         f.attrs['created_at'] = datetime.now().isoformat()
         f.attrs['n_samples'] = len(diagnostics_list)
-        f.attrs['time_start'] = float(times[0])
-        f.attrs['time_end'] = float(times[-1])
+        if len(diagnostics_list) > 0:
+            f.attrs['time_start'] = float(times[0])
+            f.attrs['time_end'] = float(times[-1])
 
         if metadata:
             for key, value in metadata.items():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -793,7 +793,7 @@ def test_turbulence_diagnostics_roundtrip(grid, tmpdir):
     }
 
     # Save diagnostics
-    save_turbulence_diagnostics(diagnostics_list, str(filename), **metadata)
+    save_turbulence_diagnostics(diagnostics_list, str(filename), metadata=metadata)
 
     # Load diagnostics
     loaded_list, loaded_metadata = load_turbulence_diagnostics(str(filename))
@@ -845,7 +845,7 @@ def test_turbulence_diagnostics_metadata_preservation(grid, tmpdir):
         "custom_field": "test_value",
     }
 
-    save_turbulence_diagnostics(diagnostics_list, str(filename), **metadata)
+    save_turbulence_diagnostics(diagnostics_list, str(filename), metadata=metadata)
     _, loaded_metadata = load_turbulence_diagnostics(str(filename))
 
     # All metadata should be preserved
@@ -893,14 +893,16 @@ def test_turbulence_diagnostics_compression(grid, tmpdir):
     filename = tmpdir / "test_turbulence_compressed.h5"
     save_turbulence_diagnostics(diagnostics_list, str(filename))
 
-    # File should exist and be smaller than uncompressed data
-    # 7 fields × 100 samples × 8 bytes/float64 = 5600 bytes uncompressed
-    # With compression, should be significantly smaller
-    file_size = filename.stat().st_size
-    uncompressed_size = 7 * 100 * 8
-
-    # Compression should reduce size (conservative test: < 2x uncompressed)
-    assert file_size < 2 * uncompressed_size, f"File too large: {file_size} > {2 * uncompressed_size}"
+    # HDF5 per-dataset structural overhead (superblock, object headers, chunk
+    # B-trees) dominates at this data size (~700 raw bytes/dataset), so an
+    # absolute file-size bound is not meaningful. Instead verify compression is
+    # enabled on every dataset (same pattern as test_checkpoint_compression and
+    # test_timeseries_compression).
+    with h5py.File(str(filename), 'r') as f:
+        for name in ('times', 'max_velocity', 'cfl_number', 'max_nonlinear',
+                     'energy_highk', 'critical_balance_ratio', 'energy_total'):
+            assert f[name].compression == 'gzip', f"{name} not gzip-compressed"
+            assert f[name].compression_opts == 4, f"{name} unexpected gzip level"
 
 
 # =============================================================================

--- a/tests/test_kz_damping.py
+++ b/tests/test_kz_damping.py
@@ -159,7 +159,6 @@ class TestKzDampingHermiteMoments:
         state = KRMHDState(
             z_plus=zeros,
             z_minus=zeros,
-            B_parallel=zeros,  # required pre-#149; ignored extra kwarg after it merges
             g=g,
             M=M,
             beta_i=1.0,

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -977,27 +977,35 @@ class TestKRMHDState:
         # Compute energy using energy() function
         E_auto = energy(state)
 
-        # Manually compute energy in Fourier space for validation
+        # Manually compute energy in Fourier space for validation.
+        # energy() normalizes perpendicular gradient energies by Nx*Ny only,
+        # summing over all z-planes (convention set in PR #77).
         Nx, Ny, Nz = grid.Nx, grid.Ny, grid.Nz
-        N_total = Nx * Ny * Nz
-        norm_factor = 1.0 / N_total
+        norm_factor = 1.0 / (Nx * Ny)
 
         kx_3d = grid.kx[jnp.newaxis, jnp.newaxis, :]
         ky_3d = grid.ky[jnp.newaxis, :, jnp.newaxis]
         k_perp_squared = kx_3d**2 + ky_3d**2
 
-        # Create kx=0 mask
-        kx_zero_mask = (grid.kx[jnp.newaxis, jnp.newaxis, :] == 0.0)
+        # rfft double-counting: factor 2 for 0 < kx < Nyquist (implicit negative-kx
+        # partner), factor 1 for kx=0 and the real-valued kx=Nyquist plane —
+        # mirrors the kx_middle mask in energy()
+        kx_zero = (kx_3d == 0.0)
+        kx_nyquist = (
+            (kx_3d == Nx // 2) if (Nx % 2 == 0)
+            else jnp.zeros_like(kx_3d, dtype=bool)
+        )
+        kx_middle = ~(kx_zero | kx_nyquist)
 
         # Manual calculation
         A_mag_sq = k_perp_squared * jnp.abs(state.A_parallel) ** 2
         E_mag_manual = 0.5 * norm_factor * jnp.sum(
-            jnp.where(kx_zero_mask, A_mag_sq, 2.0 * A_mag_sq)
+            jnp.where(kx_middle, 2.0 * A_mag_sq, A_mag_sq)
         ).real
 
         phi_mag_sq = k_perp_squared * jnp.abs(state.phi) ** 2
         E_kin_manual = 0.5 * norm_factor * jnp.sum(
-            jnp.where(kx_zero_mask, phi_mag_sq, 2.0 * phi_mag_sq)
+            jnp.where(kx_middle, 2.0 * phi_mag_sq, phi_mag_sq)
         ).real
 
         # Should match exactly (same calculation)


### PR DESCRIPTION
Fixes all 12 long-standing test failures on `main` (`uv run pytest tests/ -q --ignore=tests/test_modal.py --ignore=tests/test_performance.py`). None of these tests run in CI, which is how they persisted. Verdict per group: two were **tests born broken**, one was a **production bug**, one was a **stale test contract**.

## 1. `tests/test_run_simulation.py` — 7 failures (`UnboundLocalError`) — production bug

`scripts/run_simulation.py` had function-local `import numpy as np` statements (introduced in e6b7193, "Run on Modal (#101)") inside `if config.forcing.enabled:` branches of `run_simulation()`. Python's compile-time scoping makes `np` local to the **entire** function, shadowing the module-level import (line 33). Any forcing-disabled run (the default for decaying/Orszag configs) reached `np.savez(...)` in the spectra-saving block with `np` never bound. Confirming evidence: `test_run_simulation_with_forcing` was the only integration test passing, because the loop-body import binds `np` on the first forced step.

**Fix:** delete the two redundant local imports; the module-level import already exists.

## 2. `tests/test_io.py` turbulence diagnostics — 4 failures — mixed

- **roundtrip / metadata_preservation (`TypeError`) — tests born broken.** Added in e5dc148 (merged via 23b8856, #84) calling `save_turbulence_diagnostics(..., **metadata)`, but the implementation has taken `metadata: Optional[Dict]` since its introduction (e5ac716) — the kwargs API never existed. The production caller (`examples/benchmarks/alfvenic_cascade_benchmark.py`) uses `metadata=metadata`. Fix: tests now call `metadata=metadata`.
- **empty_list (`IndexError`) — production bug.** The writer indexed `times[0]`/`times[-1]` for the `time_start`/`time_end` attrs, crashing on an empty list; the test's contract (empty round-trip) is reasonable. Fix: guard the two attrs with `if len(diagnostics_list) > 0:`. **This is the only production-code behavior change in this PR** — empty saves now succeed and simply omit those two attrs (previously they could not be created at all, so no consumer can regress).
- **compression (`AssertionError`) — test born broken.** It asserted file size < 2× raw data bytes (11,200 B), but HDF5 structural overhead makes that bound unachievable at this data size: measured 24,440 B with gzip and 13,792 B even fully uncompressed. Fix: assert per-dataset `.compression == 'gzip'` / `.compression_opts == 4`, the established pattern of `test_checkpoint_compression` and `test_timeseries_compression`.

## 3. `tests/test_physics.py::TestKRMHDState::test_energy_parseval_validation` — stale contract

The test's manual formula normalized by `1/(Nx·Ny·Nz)`, copied from the original `energy()` implementation (42e16e8). Commit 7b1772e ("Fix Orszag-Tang benchmark: energy calculation and time normalization", #77) deliberately changed `energy()` to normalize perpendicular gradient energies by `1/(Nx·Ny)` (summing over all z-planes, matching original GANDALF/thesis energies) without updating this test — producing an exact, deterministic factor-Nz (= 16 for the 32×32×16 grid) mismatch. The failure was not order-dependent: it reproduced identically in isolation and in the full suite.

**Fix:** update the manual formula to the current `1/(Nx·Ny)` convention, and harden it by mirroring `energy()`'s `kx_middle` mask (no doubling of the kx=0 and real-valued kx=Nyquist planes), so the check is exact for any state rather than only for states without Nyquist content.

## Tidy-up

Removed the now-dead `B_parallel=zeros` kwarg from the `KRMHDState` construction in `tests/test_kz_damping.py` (field removed in #149; the extra kwarg was silently ignored).

## Test results

| | passed | failed | skipped |
|---|---|---|---|
| main @ 6377c51 | 630 | **12** | 1 |
| this branch | **642** | **0** | 1 |

Every fix was validated individually (each failing test/file re-run) and via three consecutive green full-suite runs.