### PR TITLE
Fix three float32 tolerance assertions that fail only on Linux CI

### DIFF
--- a/tests/test_hermite.py
+++ b/tests/test_hermite.py
@@ -66,6 +66,8 @@ def test_hermite_recurrence_relation():
     """Verify H_{m+1} = 2v·H_m - 2m·H_{m-1} explicitly."""
     v = jnp.linspace(-3.0, 3.0, 50)
 
+    eps = float(jnp.finfo(v.dtype).eps)
+
     for m in range(1, 10):
         H_m_minus_1 = hermite_polynomial(m - 1, v)
         H_m = hermite_polynomial(m, v)
@@ -74,9 +76,37 @@ def test_hermite_recurrence_relation():
         # Apply recurrence relation
         H_m_plus_1_recurrence = 2.0 * v * H_m - 2.0 * m * H_m_minus_1
 
-        assert jnp.allclose(
-            H_m_plus_1_computed, H_m_plus_1_recurrence, rtol=1e-5, atol=1e-6
-        ), f"Recurrence relation failed for m={m}"
+        # Both sides are independent floating-point evaluations of the *same*
+        # ill-conditioned expression: near a root of H_{m+1} the two terms
+        # 2v*H_m and 2m*H_{m-1} cancel almost completely, so the absolute
+        # uncertainty is set by the size of the terms being subtracted, not by
+        # the size of the result.  An absolute atol is therefore meaningless.
+        # On v in [-3, 3] those terms reach ~6.7e3 at m=4, so any float32
+        # evaluation carries ~eps*6.7e3 = 8e-4 of absolute noise (verified
+        # against a float64 reference), i.e. 800x the old atol=1e-6.  The old
+        # assertion passed on macOS only because XLA happened to contract both
+        # sides into the same FMA sequence; the x86-64 jaxlib build contracts
+        # them differently, so Linux CI saw the (equally valid) difference.
+        #
+        # Scale the tolerance by the cancellation magnitude instead.  The factor
+        # 32 covers the accumulated round-off of both evaluations (each a few
+        # eps*scale) with ~5x headroom, while a genuine error in the recurrence
+        # coefficients would show up at O(max|H_{m+1}|) -- larger than this
+        # tolerance by 5 orders of magnitude at every m tested here.
+        cancellation_scale = float(
+            jnp.max(jnp.abs(2.0 * v * H_m) + jnp.abs(2.0 * m * H_m_minus_1))
+        )
+        tol = 32.0 * eps * cancellation_scale
+        max_deviation = float(
+            jnp.max(jnp.abs(H_m_plus_1_computed - H_m_plus_1_recurrence))
+        )
+
+        assert max_deviation <= tol, (
+            f"Recurrence relation failed for m={m}: max deviation "
+            f"{max_deviation:.3e} exceeds tolerance {tol:.3e} "
+            f"(cancellation scale {cancellation_scale:.3e}, "
+            f"max|H_{m + 1}| = {float(jnp.max(jnp.abs(H_m_plus_1_computed))):.3e})"
+        )
 
 
 def test_hermite_known_values():
@@ -375,27 +405,57 @@ def test_round_trip_convergence_with_M(velocity_grid_standard):
     g_v_original = jnp.exp(-0.5 * v**2) * (1.0 + 0.1 * jnp.sin(v))
     g_v_original /= jnp.trapezoid(g_v_original, v)  # Normalize
 
+    # g(v) = even * (1 + odd), so moments of alternating parity contribute in
+    # pairs and the error is a staircase that only drops on every *second* M
+    # (measured: M=3 and M=4 give the same error to 7 digits).  Step M by 2 in
+    # the resolvable range so that every compared step is a real improvement.
     errors = []
-    M_values = [5, 10, 15, 20, 25]
+    M_values = [2, 4, 6, 8, 10, 15, 20, 25]
 
     for M in M_values:
         moments = distribution_to_moments(g_v_original, v, M, v_th)
         g_v_reconstructed = moments_to_distribution(moments, v, v_th, M)
 
         error = jnp.sqrt(jnp.trapezoid((g_v_original - g_v_reconstructed) ** 2, v))
-        errors.append(error)
+        errors.append(float(error))
 
-    # Error should generally decrease with M (allow small fluctuations)
-    # Check that final error is significantly smaller than initial error
+    # Round-off floor of the round trip.  Each moment is a 1000-point trapezoid
+    # quadrature (~log2(1000) = 10 eps of accumulated relative error) and the
+    # reconstruction sums M+1 basis functions (~sqrt(M) eps), so the round-trip
+    # error cannot fall below a few tens of eps relative to ||g||.  Measured
+    # plateau is 5.1 * eps * ||g|| = 3.2e-7, so 30 eps is a safe upper bound
+    # with ~6x headroom.  Beyond that point the error is pure round-off noise
+    # and its ordering in M is decided by the FFT/BLAS kernels of the specific
+    # jaxlib build -- which is exactly why the old strict-monotonicity check
+    # passed on macOS and on Linux/py3.10 but failed on Linux/py3.12.
+    eps = float(jnp.finfo(v.dtype).eps)
+    g_norm = float(jnp.sqrt(jnp.trapezoid(g_v_original**2, v)))
+    noise_floor = 30.0 * eps * g_norm
+
+    # Truncation error must fall monotonically while it still dominates
+    # round-off.  Every such step here is a factor >= 8 drop, far above noise.
+    for i in range(len(errors) - 1):
+        if errors[i] <= noise_floor:
+            break  # saturated: further differences are round-off, not physics
+        assert errors[i + 1] < errors[i], (
+            f"Error did not improve above the round-off floor "
+            f"({noise_floor:.3e}): M={M_values[i]} error={errors[i]:.6e}, "
+            f"M={M_values[i + 1]} error={errors[i + 1]:.6e}"
+        )
+
+    # Overall convergence must be dramatic, not marginal.
     assert errors[-1] < errors[0] * 0.5, (
         f"Error not decreasing sufficiently: "
-        f"M={M_values[0]} error={errors[0]}, M={M_values[-1]} error={errors[-1]}"
+        f"M={M_values[0]} error={errors[0]:.6e}, "
+        f"M={M_values[-1]} error={errors[-1]:.6e}"
     )
 
-    # Check that most steps show improvement (allow 1 non-improvement)
-    improvements = sum(1 for i in range(len(errors) - 1) if errors[i] > errors[i + 1])
-    assert improvements >= len(errors) - 2, (
-        f"Too many non-improvements in convergence: {improvements}/{len(errors)-1}"
+    # ...and the converged tail must actually sit at the float32 floor rather
+    # than plateauing at some larger value (which would indicate a real
+    # truncation or normalization bug in the transform pair).
+    assert errors[-1] <= noise_floor, (
+        f"Round-trip error saturated at {errors[-1]:.6e}, above the expected "
+        f"float32 round-off floor {noise_floor:.3e}"
     )
 
 

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -311,11 +311,22 @@ class TestPoissonBracket2D:
         bracket_k = poisson_bracket_2d(f_k, g_k, grid.kx, grid.ky, grid.Ny, grid.Nx, grid.dealias_mask)
 
         # Check k=0 mode (spatial mean)
-        k0_mode = jnp.abs(bracket_k[0, 0])
+        k0_mode = float(jnp.abs(bracket_k[0, 0]))
 
-        # Should be zero (derivatives kill constants)
-        # Tolerance accounts for dealiasing and FFT round-off with random fields
-        assert k0_mode < 0.01, f"k=0 mode should be zero, got {k0_mode}"
+        # Same scaling argument as test_mean_preserving_3d: bracket_k[0,0] is
+        # the unnormalized sum of {f,g} over all N = Ny*Nx points, so its
+        # float32 floor is eps * log2(N) * ||{f,g}||_2 = 4e-2 here -- four times
+        # *larger* than the old absolute `< 0.01`, which therefore only passed
+        # by luck (the measured value is 3.9e-3, well inside the bound but with
+        # only 2.6x margin).  Scale to the bracket's own Fourier magnitude so
+        # the assertion is meaningful on any FFT backend.
+        bracket_scale = float(jnp.max(jnp.abs(bracket_k)))
+
+        assert k0_mode < 1e-5 * bracket_scale, (
+            f"k=0 mode should be zero, got {k0_mode} "
+            f"(bracket scale {bracket_scale:.4g}, "
+            f"relative {k0_mode / bracket_scale:.3e})"
+        )
 
     def test_l2_norm_conservation(self):
         """
@@ -593,10 +604,33 @@ class TestPoissonBracket3D:
         bracket_k = poisson_bracket_3d(f_k, g_k, grid.kx, grid.ky, grid.Nz, grid.Ny, grid.Nx, grid.dealias_mask)
 
         # Check k=0 mode
-        k0_mode = jnp.abs(bracket_k[0, 0, 0])
+        k0_mode = float(jnp.abs(bracket_k[0, 0, 0]))
 
-        # Should be zero (tolerance accounts for dealiasing and FFT round-off)
-        assert k0_mode < 1e-4, f"k=0 mode should be zero in 3D, got {k0_mode}"
+        # bracket_k[0,0,0] is the *unnormalized* sum of {f,g} over all
+        # N = Nz*Ny*Nx = 131072 grid points.  It vanishes analytically because
+        # {f,g} is a total derivative, but numerically it is a near-total
+        # cancellation: its two halves, sum(df/dx * dg/dy) and
+        # sum(df/dy * dg/dx), are each ~2.6e4 here and cancel to zero.  The
+        # float32 floor for such a sum is the standard FFT accumulation bound
+        # eps * log2(N) * ||{f,g}||_2 = 1.2e-7 * 17 * 1.1e4 = 2e-2, i.e. about
+        # one eps relative to the bracket's largest Fourier amplitude.
+        #
+        # The old absolute `< 1e-4` demanded ~200x better than float32 can
+        # deliver and passed on macOS only because the arm64 FFT kernel happened
+        # to cancel exactly.  Linux CI produced 2^-8 (py3.12) and 3*2^-8
+        # (py3.10) -- both exactly at this floor, and both a couple of ulps of
+        # the 2.6e4 partial sums.  Scale the tolerance to the bracket's own
+        # magnitude instead, which is what "the mean is preserved" means: the
+        # k=0 mode must be negligible next to the modes that carry the signal.
+        # 1e-5 is ~84 eps, so it leaves ~70x margin over the worst observed
+        # value while still catching any real leak into the mean.
+        bracket_scale = float(jnp.max(jnp.abs(bracket_k)))
+
+        assert k0_mode < 1e-5 * bracket_scale, (
+            f"k=0 mode should be zero in 3D, got {k0_mode} "
+            f"(bracket scale {bracket_scale:.4g}, "
+            f"relative {k0_mode / bracket_scale:.3e})"
+        )
 
 
 class TestKRMHDState:


### PR DESCRIPTION
PR #150 added the first Linux CI for this repo, and its very first run surfaced three test failures that never appear on the maintainer's macOS arm64 machine. All three turned out to be **assertions that are tighter than float32 can deliver** — they passed on arm64 only because that jaxlib build happens to round favourably. **No production code is changed; the numerics are sound.**

The decisive evidence is that the *same* test fails on Linux/py3.12 but passes on Linux/py3.10, and `test_mean_preserving_3d` returns a *different* residual on each (`2^-8` vs `3*2^-8`). A deterministic logic error cannot do that; float32 round-off whose exact value depends on the FFT/BLAS kernels of a specific jaxlib build can.

Every tolerance below is derived from the expected round-off magnitude, then checked to still catch a real bug — not tuned until green.

---

### 1. `test_hermite_recurrence_relation` — "failed for m=4"

**Root cause.** The test compares two independent float32 evaluations of the *same* expression, `H_{m+1} = 2v*H_m - 2m*H_{m-1}`, with `atol=1e-6`. Near a root of `H_{m+1}` the two terms cancel almost completely, so the absolute uncertainty is set by the size of the terms being *subtracted*, not by the size of the result. On `v` in `[-3,3]` those terms reach **6.7e3 at m=4**, so any float32 evaluation carries `eps * 6.7e3 ~= 8e-4` of absolute noise — confirmed against a float64 reference (`err_vs_f64 = 8.4e-4`), which is **800x the asserted `atol=1e-6`**.

The two sides agreed *bitwise* on arm64 (deviation exactly 0 at m=4) only because XLA contracted both into the same FMA sequence. The x86-64 jaxlib build contracts them differently; both results are equally valid float32.

**Fix.** Scale the tolerance by the cancellation magnitude: `32 * eps * max(|2v*H_m| + |2m*H_{m-1}|)`. The factor 32 covers the accumulated round-off of *both* evaluations (each a few `eps*scale`) with ~5x headroom.

| m | deviation (macOS) | tolerance | margin | 0.1% coefficient bug |
|---|---|---|---|---|
| 1 | 9.5e-7 | 1.4e-4 | 152x | caught (0.002) |
| 4 | 0 | 2.6e-2 | — | caught (1.44) |
| 7 | 3.9e-3 | 1.65 | 422x | caught (198) |
| 9 | 3.1e-2 | 11.8 | 378x | caught (871) |

A genuine error in the recurrence coefficients shows up at `O(max|H_{m+1}|)`, ~5 orders of magnitude above this tolerance at every m.

---

### 2. `test_round_trip_convergence_with_M` — "Too many non-improvements: 2/4"

**Root cause.** The test required near-monotonic error decrease across `M = 5,10,15,20,25`, but **in float32 the round-trip error saturates at the round-off floor from M~10 onward**:

| M | float32 error | float64 error |
|---|---|---|
| 5 | 5.159e-5 | 5.159e-5 |
| 10 | 3.529e-7 | 1.448e-7 |
| 15 | 3.2327e-7 | 6.06e-12 |
| 20 | 3.2326e-7 | 4.00e-15 |
| 25 | 3.2352e-7 | 1.09e-16 |

float64 keeps converging by 10 orders of magnitude; float32 flatlines at `3.23e-7 = 5.1 * eps * ||g||`. Past saturation the ordering in M is decided purely by round-off — on macOS the M=15 -> 20 comparison passed by a *relative margin of 3.6e-5* (3.232706e-7 vs 3.232589e-7). Pure luck. Linux/py3.10 got 3/4 and passed; Linux/py3.12 got 2/4 and failed. **Strict monotonicity below the noise floor is unachievable on any platform.**

**Fix.** Two changes:

- **Step M by 2 in the resolvable range** (`M = 2,4,6,8,10,15,20,25`). `g(v) = even * (1 + odd)`, so moments of alternating parity contribute in pairs and the error is a *staircase* that only drops on every second M — M=3 and M=4 give identical errors to 7 digits, so the original stride made some comparisons round-off coin flips even in exact arithmetic.
- **Require strict improvement only above a noise floor** of `30 * eps * ||g|| = 1.9e-6`. Justification: each moment is a 1000-point trapezoid quadrature (`~log2(1000) = 10 eps`) and the reconstruction sums M+1 basis functions (`~sqrt(M) eps`), so a few tens of eps is a safe upper bound; the measured plateau is `5.1 eps`, giving 6x headroom.

This makes the test **stronger** than before: four *required* improvements of 9.0x, 13.0x, 16.9x and 8.7x, versus the old "3 of 4 loose comparisons". It also adds an assertion that the tail actually *reaches* the floor (`errors[-1] <= noise_floor`, 5.9x margin), which would catch a genuine truncation or normalization bug in the transform pair — the old test could not.

---

### 3. `test_mean_preserving_3d` — "got 0.00390625"

**Root cause.** `rfftn_forward` is unnormalized, so `bracket_k[0,0,0]` is the **raw sum of `{f,g}` over all N = 64x64x32 = 131072 grid points**. It vanishes analytically because `{f,g}` is a total derivative, but numerically it is a near-total cancellation: its two halves, `sum(df/dx * dg/dy)` and `sum(df/dy * dg/dx)`, are each **~2.6e4** and cancel to zero.

The float32 floor for such a sum is the standard FFT accumulation bound `eps * log2(N) * ||{f,g}||_2 = 1.2e-7 * 17 * 1.1e4 =` **2.2e-2**. The reported Linux values `2^-8 = 3.9e-3` and `3*2^-8 = 1.17e-2` sit exactly in that band, and are a couple of ulps of the 2.6e4 partial sums (1 ulp at 2.6e4 is `2^-9`). **The old absolute `< 1e-4` demanded ~200x better than float32 can deliver**; macOS returned exactly 0 by luck.

Worth noting: the constant offsets (`f+2`, `g-4`) are numerically irrelevant here — spectral derivatives multiply by `ik`, which zeroes the DC bin exactly. I verified the bracket is bit-identical with and without them, so they do *not* inflate the round-off.

**Fix.** Scale to the bracket's own peak Fourier amplitude: `k0_mode < 1e-5 * max|bracket_k|`. This is what "the mean is preserved" actually means — the k=0 mode must be negligible next to the modes carrying the signal. `1e-5` is ~84 eps, giving **69x margin over the worst observed Linux value** while still catching any real leak into the mean.

**Also fixes the 2D twin** (`TestPoissonBracket2D::test_mean_preserving`), which has the identical flaw and was the next flake waiting to happen: its absolute tolerance of `0.01` is **4x below its own round-off bound of 0.043**, and it passed with only 2.6x margin. It now has 389x margin.

---

### Why these are platform-independent, not arm64-lucky

Each tolerance is now derived from a quantity computed *at runtime from the data itself* — the cancellation magnitude, the field norm, the bracket's peak amplitude — multiplied by a small factor times machine epsilon. Nothing is pinned to an absolute constant that only holds for one FFT backend, one FMA contraction choice, or one grid size.

### Verification

- **Native macOS arm64:** full suite `uv run pytest tests/ -q --ignore=tests/test_performance.py` (counts in a follow-up comment).
- **Linux x86-64:** validated by this PR's own `Tests` workflow run on Ubuntu, Python 3.10 and 3.12. Docker `linux/amd64` under QEMU on Apple Silicon was too slow to be usable, and real CI is the more faithful check anyway.

### Incidental observation (not fixed, out of scope)

`hermite_polynomials_all` overflows float32 for `M >= 32` on `v` in `[-10,10]`: `H_32(10) ~ 20^32 > 3.4e38` becomes `inf`, then `inf * 0` (underflowed Gaussian) becomes `NaN`. The basis functions `psi_m` themselves are perfectly small — it is only the unscaled intermediate that overflows. All tests stay at `M <= 25` (`max|H| = 6e31`), so nothing here is affected, but computing `psi_m` in log-space would lift the usable moment range.
